### PR TITLE
chore: Add .npmrc

### DIFF
--- a/packages/core-web/.npmrc
+++ b/packages/core-web/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted


### PR DESCRIPTION
Change package `node-linker` setting to allow for bundled dependencies