### PR TITLE
chore: added tree shaking and bundling optimizations

### DIFF
--- a/packages/core-web/package.json
+++ b/packages/core-web/package.json
@@ -15,18 +15,20 @@
   },
   "files": [
     "dist",
-    "src",
-    "wasm"
+    "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/worker.js",
+    "./dist/index.js"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "fedimint-client-wasm": "file:./wasm"
+    "@fedimint/fedimint-client-wasm": "file:./wasm"
   },
-  "bundledDependencies": [
-    "fedimint-client-wasm"
+  "bundleDependencies": [
+    "@fedimint/fedimint-client-wasm"
   ],
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/packages/core-web/src/worker.js
+++ b/packages/core-web/src/worker.js
@@ -1,6 +1,4 @@
-// import { WasmClient } from '../wasm/fedimint_client_wasm.js'
-// import { WasmClient } from 'fedimint-client-wasm'
-// import wasm from '../wasm/fedimint_client_wasm_bg.wasm'
+// Web Worker for fedimint-client-wasm to run in the browser
 
 let WasmClient = null
 let client = null
@@ -15,7 +13,7 @@ self.onmessage = async (event) => {
   const { type, payload, requestId } = event.data
 
   if (type === 'init') {
-    WasmClient = (await import('fedimint-client-wasm')).WasmClient
+    WasmClient = (await import('@fedimint/fedimint-client-wasm')).WasmClient
     self.postMessage({ type: 'initialized', data: {}, requestId })
   } else if (type === 'open') {
     const { clientName } = payload

--- a/packages/core-web/wasm/package.json
+++ b/packages/core-web/wasm/package.json
@@ -1,11 +1,8 @@
 {
-  "name": "fedimint-client-wasm",
+  "name": "@fedimint/fedimint-client-wasm",
+  "private": true,
   "type": "module",
-  "collaborators": [
-    "The Fedimint Developers"
-  ],
-  "description": "fedimint client for wasm",
-  "version": "0.5.0-alpha",
+  "description": "Wasm-pack output for fedimint-client-wasm",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
 
   packages/core-web:
     dependencies:
-      fedimint-client-wasm:
+      '@fedimint/fedimint-client-wasm':
         specifier: file:./wasm
         version: file:packages/core-web/wasm
     devDependencies:
@@ -436,6 +436,9 @@ packages:
   '@eslint/js@8.57.0':
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@fedimint/fedimint-client-wasm@file:packages/core-web/wasm':
+    resolution: {directory: packages/core-web/wasm, type: directory}
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -990,9 +993,6 @@ packages:
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
-
-  fedimint-client-wasm@file:packages/core-web/wasm:
-    resolution: {directory: packages/core-web/wasm, type: directory}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -2133,6 +2133,8 @@ snapshots:
 
   '@eslint/js@8.57.0': {}
 
+  '@fedimint/fedimint-client-wasm@file:packages/core-web/wasm': {}
+
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -2729,8 +2731,6 @@ snapshots:
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
-
-  fedimint-client-wasm@file:packages/core-web/wasm: {}
 
   file-entry-cache@6.0.1:
     dependencies:


### PR DESCRIPTION

* Added Side Effects for tree shaking optimizations
* updated bundled fedimint-client-wasm to private. It shouldn't link to any other package on npm.
* removed wasm folder from the bundled package - since it's already included as `bundledDependencies`