### PR TITLE
Refactor Wallet into multiple Composable services

### DIFF
--- a/.changeset/pink-socks-fetch.md
+++ b/.changeset/pink-socks-fetch.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core-web': patch
+---
+
+Refactor FedimintWallet into many composable services"

--- a/examples/vite-core/src/App.tsx
+++ b/examples/vite-core/src/App.tsx
@@ -24,7 +24,7 @@ const useBalance = (checkIsOpen: () => void) => {
   const [balance, setBalance] = useState(0)
 
   useEffect(() => {
-    const unsubscribe = wallet.subscribeBalance((balance: number) => {
+    const unsubscribe = wallet.balance.subscribeBalance((balance: number) => {
       // checks if the wallet is open when the first
       // subscription event fires.
       // TODO: make a subscription to the wallet open status
@@ -106,7 +106,7 @@ const JoinFederation = ({
     console.log('Joining federation:', inviteCode)
     try {
       setJoining(true)
-      const res = await wallet?.joinFederation(inviteCode)
+      const res = await wallet.joinFederation(inviteCode)
       console.log('join federation res', res)
       setJoinResult('Joined!')
       setJoinError('')
@@ -150,7 +150,7 @@ const RedeemEcash = () => {
   const handleRedeem = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
-      const res = await wallet.redeemEcash(ecashInput)
+      const res = await wallet.mint.redeemEcash(ecashInput)
       console.log('redeem ecash res', res)
       setRedeemResult('Redeemed!')
       setRedeemError('')
@@ -187,7 +187,7 @@ const SendLightning = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
-      await wallet.payBolt11Invoice(lightningInput)
+      await wallet.lightning.payBolt11Invoice(lightningInput)
       setLightningResult('Paid!')
       setLightningError('')
     } catch (e) {
@@ -228,7 +228,7 @@ const GenerateLightningInvoice = () => {
     setError('')
     setGenerating(true)
     try {
-      const response = await wallet.createBolt11Invoice(
+      const response = await wallet.lightning.createBolt11Invoice(
         Number(amount),
         description,
       )

--- a/packages/core-web/rollup.config.js
+++ b/packages/core-web/rollup.config.js
@@ -14,6 +14,6 @@ export default [
       sourcemap: true,
     },
     plugins: [typescript(), terser()],
-    external: ['fedimint-client-wasm'],
+    external: ['@fedimint/fedimint-client-wasm'],
   },
 ]

--- a/packages/core-web/src/FedimintWallet.test.ts
+++ b/packages/core-web/src/FedimintWallet.test.ts
@@ -64,7 +64,7 @@ test('Error on open & join if wallet is already open', async () => {
 test('getConfig', async () => {
   expect(wallet).toBeDefined()
   expect(wallet.isOpen()).toBe(true)
-  const config = await wallet.getConfig()
+  const config = await wallet.federation.getConfig()
   expect(config).toBeDefined()
 })
 
@@ -72,5 +72,5 @@ test('empty getBalance', async () => {
   expect(wallet).toBeDefined()
   expect(wallet.isOpen()).toBe(true)
   await expect(wallet.waitForOpen()).resolves.toBeUndefined()
-  await expect(wallet.getBalance()).resolves.toEqual(0)
+  await expect(wallet.balance.getBalance()).resolves.toEqual(0)
 })

--- a/packages/core-web/src/FedimintWallet.test.ts
+++ b/packages/core-web/src/FedimintWallet.test.ts
@@ -46,9 +46,7 @@ test('Error on open & join if wallet is already open', async () => {
     await wallet.open(randomTestingId)
   } catch (error) {
     expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe(
-      'The FedimintWallet is already open. You can only call `FedimintWallet.open on closed clients.`',
-    )
+    expect((error as Error).message).toBe('The FedimintWallet is already open.')
   }
 
   // Test joining federation on an already open wallet
@@ -57,7 +55,7 @@ test('Error on open & join if wallet is already open', async () => {
   } catch (error) {
     expect(error).toBeInstanceOf(Error)
     expect((error as Error).message).toBe(
-      'The FedimintWallet is already open. You can only call `FedimintWallet.joinFederation` on closed clients.',
+      'The FedimintWallet is already open. You can only call `joinFederation` on closed clients.',
     )
   }
 })

--- a/packages/core-web/src/FedimintWallet.ts
+++ b/packages/core-web/src/FedimintWallet.ts
@@ -99,7 +99,7 @@ export class FedimintWallet {
     // TODO: Determine if this should be safe or throw
     if (this._isOpen)
       throw new Error(
-        'The FedimintWallet is already open. You can only call `FedimintWallet.joinFederation` on closed clients.',
+        'The FedimintWallet is already open. You can only call `joinFederation` on closed clients.',
       )
     const response = await this.client.sendSingleMessage('join', {
       inviteCode,

--- a/packages/core-web/src/FedimintWallet.ts
+++ b/packages/core-web/src/FedimintWallet.ts
@@ -1,28 +1,26 @@
+import { WorkerClient } from './transport/WorkerClient'
 import {
-  JSONValue,
-  JSONObject,
-  LightningGateway,
-  OutgoingLightningPayment,
-  LnPayState,
-  LnReceiveState,
-  StreamResult,
-  StreamError,
-  CreateBolt11Response,
-  ModuleKind,
-  GatewayInfo,
-  CancelFunction,
-} from './types/wallet'
+  BalanceService,
+  MintService,
+  LightningService,
+  FederationService,
+  RecoveryService,
+} from './services'
 
 const DEFAULT_CLIENT_NAME = 'fm-default' as const
 
 export class FedimintWallet {
-  private worker: Worker | null = null
-  private initPromise: Promise<void> | null = null
+  private client: WorkerClient
+
+  public balance: BalanceService
+  public mint: MintService
+  public lightning: LightningService
+  public federation: FederationService
+  public recovery: RecoveryService
+
   private openPromise: Promise<void> | null = null
   private resolveOpen: () => void = () => {}
   private _isOpen: boolean = false
-  private requestCounter: number = 0
-  private requestCallbacks: Map<number, (value: any) => void> = new Map()
 
   /**
    * Creates a new instance of FedimintWallet.
@@ -51,15 +49,27 @@ export class FedimintWallet {
    * // Create a wallet with lazy initialization
    * const lazyWallet = new FedimintWallet(true);
    * // Some time later...
-   * wallet.initialize();
-   * wallet.open();
+   * lazyWallet.initialize();
+   * lazyWallet.open();
    */
   constructor(lazy: boolean = false) {
     this.openPromise = new Promise((resolve) => {
       this.resolveOpen = resolve
     })
-    if (lazy) return
-    this.initialize()
+    this.client = new WorkerClient(new URL('worker.js', import.meta.url))
+    this.mint = new MintService(this.client)
+    this.lightning = new LightningService(this.client)
+    this.balance = new BalanceService(this.client)
+    this.federation = new FederationService(this.client)
+    this.recovery = new RecoveryService(this.client)
+
+    if (!lazy) {
+      this.initialize()
+    }
+  }
+
+  async initialize() {
+    await this.client.initialize()
   }
 
   async waitForOpen() {
@@ -67,57 +77,13 @@ export class FedimintWallet {
     return this.openPromise
   }
 
-  private getNextRequestId(): number {
-    return ++this.requestCounter
-  }
-
-  // Sends a single message and deletes the request callback
-  // The first response
-  private sendSingleMessage(type: string, payload?: any): Promise<any> {
-    return new Promise((resolve, reject) => {
-      const requestId = this.getNextRequestId()
-      this.requestCallbacks.set(requestId, (data) => {
-        this.requestCallbacks.delete(requestId)
-        if (data.data) resolve(data.data)
-        else if (data.error) reject(data.error)
-      })
-      try {
-        this.worker!.postMessage({ type, payload, requestId })
-      } catch (e) {
-        reject(e)
-      }
-    })
-  }
-
-  // Setup
-  initialize() {
-    if (this.initPromise) return this.initPromise
-    this.worker = new Worker(new URL('worker.js', import.meta.url), {
-      type: 'module',
-    })
-    this.worker.onmessage = this.handleWorkerMessage.bind(this)
-    // TODO: HANDLE RETURNED INIT
-    this.initPromise = this.sendSingleMessage('init')
-    return this.initPromise
-  }
-
-  private handleWorkerMessage(event: MessageEvent) {
-    const { type, requestId, ...data } = event.data
-    const streamCallback = this.requestCallbacks.get(requestId)
-    // TODO: Handle errors... maybe have another callbacks list for errors?
-    if (streamCallback) {
-      streamCallback(data) // {data: something} OR {error: something}
-    }
-  }
-
   async open(clientName: string = DEFAULT_CLIENT_NAME) {
-    await this.initialize()
+    await this.client.initialize()
     // TODO: Determine if this should be safe or throw
-    if (this._isOpen)
-      throw new Error(
-        'The FedimintWallet is already open. You can only call `FedimintWallet.open on closed clients.`',
-      )
-    const { success } = await this.sendSingleMessage('open', { clientName })
+    if (this._isOpen) throw new Error('The FedimintWallet is already open.')
+    const { success } = await this.client.sendSingleMessage('open', {
+      clientName,
+    })
     if (success) {
       this._isOpen = !!success
       this.resolveOpen()
@@ -129,13 +95,13 @@ export class FedimintWallet {
     inviteCode: string,
     clientName: string = DEFAULT_CLIENT_NAME,
   ) {
-    await this.initialize()
+    await this.client.initialize()
     // TODO: Determine if this should be safe or throw
     if (this._isOpen)
       throw new Error(
         'The FedimintWallet is already open. You can only call `FedimintWallet.joinFederation` on closed clients.',
       )
-    const response = await this.sendSingleMessage('join', {
+    const response = await this.client.sendSingleMessage('join', {
       inviteCode,
       clientName,
     })
@@ -146,406 +112,16 @@ export class FedimintWallet {
   }
 
   /**
-   * @summary Initiates an RPC stream with the specified module and method.
-   *
-   * @description
-   * This function sets up an RPC stream by sending a request to a worker and
-   * handling responses asynchronously. It ensures that unsubscription is handled
-   * correctly, even if the unsubscribe function is called before the subscription
-   * is fully established, by deferring the unsubscription attempt using `setTimeout`.
-   *
-   * The function operates in a non-blocking manner, leveraging Promises to manage
-   * asynchronous operations and callbacks to handle responses.
-   *
-   *
-   * @template Response - The expected type of the successful response.
-   * @template Body - The type of the request body.
-   * @param module - The module kind to interact with.
-   * @param method - The method name to invoke on the module.
-   * @param body - The request payload.
-   * @param onSuccess - Callback invoked with the response data on success.
-   * @param onError - Callback invoked with error information if an error occurs.
-   * @param onEnd - Optional callback invoked when the stream ends.
-   * @returns A function that can be called to cancel the subscription.
-   *
-   */
-  private _rpcStream<
-    Response extends JSONValue = JSONValue,
-    Body extends JSONValue = JSONValue,
-  >(
-    module: ModuleKind,
-    method: string,
-    body: Body,
-    onSuccess: (res: Response) => void,
-    onError: (res: StreamError['error']) => void,
-    onEnd: () => void = () => {},
-  ): CancelFunction {
-    const requestId = this.getNextRequestId()
-
-    let unsubscribe: (value: void) => void = () => {}
-    let isSubscribed = false
-
-    const unsubscribePromise = new Promise<void>((resolve) => {
-      unsubscribe = () => {
-        if (isSubscribed) {
-          // If already subscribed, resolve immediately to trigger unsubscription
-          resolve()
-        } else {
-          // If not yet subscribed, defer the unsubscribe attempt to the next event loop tick
-          // This ensures that subscription setup has time to complete
-          setTimeout(() => unsubscribe(), 0)
-        }
-      }
-    })
-
-    // Initiate the inner RPC stream setup asynchronously
-    this._rpcStreamInner(
-      requestId,
-      module,
-      method,
-      body,
-      onSuccess,
-      onError,
-      onEnd,
-      unsubscribePromise,
-    ).then(() => {
-      isSubscribed = true
-    })
-
-    return unsubscribe
-  }
-
-  private async _rpcStreamInner<
-    Response extends JSONValue = JSONValue,
-    Body extends JSONValue = JSONValue,
-  >(
-    requestId: number,
-    module: ModuleKind,
-    method: string,
-    body: Body,
-    onSuccess: (res: Response) => void,
-    onError: (res: StreamError['error']) => void,
-    onEnd: () => void = () => {},
-    unsubscribePromise: Promise<void>,
-    // Unsubscribe function
-  ): Promise<void> {
-    await this.openPromise
-    if (!this.worker || !this._isOpen)
-      throw new Error('FedimintWallet is not open')
-
-    this.requestCallbacks.set(requestId, (response: StreamResult<Response>) => {
-      if (response.error !== undefined) {
-        onError(response.error)
-      } else if (response.data !== undefined) {
-        onSuccess(response.data)
-      } else if (response.end !== undefined) {
-        this.requestCallbacks.delete(requestId)
-        onEnd()
-      }
-    })
-    this.worker.postMessage({
-      type: 'rpc',
-      payload: { module, method, body },
-      requestId,
-    })
-
-    unsubscribePromise.then(() => {
-      this.worker?.postMessage({
-        type: 'unsubscribe',
-        requestId,
-      })
-      this.requestCallbacks.delete(requestId)
-    })
-  }
-
-  private _rpcSingle<Response extends JSONValue = JSONValue>(
-    module: ModuleKind,
-    method: string,
-    body: JSONValue,
-  ): Promise<Response> {
-    return new Promise((resolve, reject) => {
-      this._rpcStream<Response>(module, method, body, resolve, reject)
-    })
-  }
-
-  async getBalance(): Promise<number> {
-    return await this._rpcSingle('', 'get_balance', {})
-  }
-
-  // Mint module methods
-
-  async redeemEcash(notes: string): Promise<void> {
-    await this._rpcSingle('mint', 'reissue_external_notes', {
-      oob_notes: notes, // "out of band notes"
-      extra_meta: null,
-    })
-  }
-
-  async reissueExternalNotes(
-    oobNotes: string,
-    extraMeta: JSONObject,
-  ): Promise<string> {
-    return await this._rpcSingle('mint', 'reissue_external_notes', {
-      oob_notes: oobNotes,
-      extra_meta: extraMeta,
-    })
-  }
-
-  subscribeReissueExternalNotes(
-    operationId: string,
-    onSuccess: (state: JSONValue) => void = () => {},
-    onError: (error: string) => void = () => {},
-  ) {
-    type ReissueExternalNotesState =
-      | 'Created'
-      | 'Issuing'
-      | 'Done'
-      | { Failed: { error: string } }
-
-    const unsubscribe = this._rpcStream<ReissueExternalNotesState>(
-      'mint',
-      'subscribe_reissue_external_notes',
-      { operation_id: operationId },
-      onSuccess,
-      onError,
-    )
-
-    return unsubscribe
-  }
-
-  async spendNotes(
-    minAmount: number,
-    tryCancelAfter: number,
-    includeInvite: boolean,
-    extraMeta: JSONValue,
-  ): Promise<JSONValue> {
-    return await this._rpcSingle('mint', 'spend_notes', {
-      min_amount: minAmount,
-      try_cancel_after: tryCancelAfter,
-      include_invite: includeInvite,
-      extra_meta: extraMeta,
-    })
-  }
-
-  async validateNotes(oobNotes: string): Promise<number> {
-    return await this._rpcSingle('mint', 'validate_notes', {
-      oob_notes: oobNotes,
-    })
-  }
-
-  async tryCancelSpendNotes(operationId: string): Promise<void> {
-    await this._rpcSingle('mint', 'try_cancel_spend_notes', {
-      operation_id: operationId,
-    })
-  }
-
-  subscribeSpendNotes(
-    operationId: string,
-    onSuccess: (state: JSONValue) => void = () => {},
-    onError: (error: string) => void = () => {},
-  ) {
-    const unsubscribe = this._rpcStream(
-      'mint',
-      'subscribe_spend_notes',
-      { operation_id: operationId },
-      (res) => onSuccess(res),
-      onError,
-    )
-
-    return unsubscribe
-  }
-
-  async awaitSpendOobRefund(operationId: string): Promise<JSONValue> {
-    return await this._rpcSingle('mint', 'await_spend_oob_refund', {
-      operation_id: operationId,
-    })
-  }
-
-  /**
    * This should ONLY be called when UNLOADING the wallet client.
    * After this call, the FedimintWallet instance should be discarded.
    */
   async cleanup() {
-    this.worker?.terminate()
-    this.worker = null
     this.openPromise = null
-    this.initPromise = null
-    this.requestCallbacks.clear()
     this._isOpen = false
+    this.client.cleanup()
   }
 
   isOpen() {
-    return this.worker !== null && this._isOpen
-  }
-
-  async getConfig(): Promise<JSONValue> {
-    return await this._rpcSingle('', 'get_config', {})
-  }
-
-  async getFederationId(): Promise<string> {
-    return await this._rpcSingle('', 'get_federation_id', {})
-  }
-
-  async getInviteCode(peer: number): Promise<string | null> {
-    return await this._rpcSingle('', 'get_invite_code', { peer })
-  }
-
-  async listOperations(): Promise<JSONValue[]> {
-    return await this._rpcSingle('', 'list_operations', {})
-  }
-
-  async hasPendingRecoveries(): Promise<boolean> {
-    return await this._rpcSingle('', 'has_pending_recoveries', {})
-  }
-
-  async waitForAllRecoveries(): Promise<void> {
-    await this._rpcSingle('', 'wait_for_all_recoveries', {})
-  }
-
-  /// STREAMING RPCs --------------------
-
-  subscribeBalance(
-    onSuccess: (balance: number) => void = () => {},
-    onError: (error: string) => void = () => {},
-  ) {
-    const unsubscribe = this._rpcStream<string>(
-      '',
-      'subscribe_balance_changes',
-      {},
-      (res) => onSuccess(parseInt(res)),
-      onError,
-    )
-
-    return unsubscribe
-  }
-
-  subscribeToRecoveryProgress(
-    onSuccess: (progress: {
-      module_id: number
-      progress: JSONValue
-    }) => void = () => {},
-    onError: (error: string) => void = () => {},
-  ) {
-    const unsubscribe = this._rpcStream<{
-      module_id: number
-      progress: JSONValue
-    }>('', 'subscribe_to_recovery_progress', {}, onSuccess, onError)
-
-    return unsubscribe
-  }
-
-  // Lightning Network module methods
-
-  async createBolt11InvoiceWithGateway(
-    amount: number,
-    description: string,
-    expiryTime: number | null = null,
-    extraMeta: JSONObject = {},
-    gatewayInfo: GatewayInfo,
-  ) {
-    return await this._rpcSingle('ln', 'create_bolt11_invoice', {
-      amount,
-      description,
-      expiry_time: expiryTime,
-      extra_meta: extraMeta,
-      gateway: gatewayInfo,
-    })
-  }
-
-  async createBolt11Invoice(
-    amount: number,
-    description: string,
-    expiryTime: number | null = null,
-    extraMeta: JSONObject = {},
-  ): Promise<CreateBolt11Response> {
-    await this.updateGatewayCache()
-    const gateway = await this._getDefaultGatewayInfo()
-    return await this._rpcSingle('ln', 'create_bolt11_invoice', {
-      amount,
-      description,
-      expiry_time: expiryTime,
-      extra_meta: extraMeta,
-      gateway: gateway.info,
-    })
-  }
-
-  async payBolt11InvoiceWithGateway(
-    invoice: string,
-    gatewayInfo: GatewayInfo,
-    extraMeta: JSONObject = {},
-  ) {
-    return await this._rpcSingle('ln', 'pay_bolt11_invoice', {
-      maybe_gateway: gatewayInfo,
-      invoice,
-      extra_meta: extraMeta,
-    })
-  }
-
-  async _getDefaultGatewayInfo(): Promise<LightningGateway> {
-    const gateways = await this.listGateways()
-    return gateways[0]
-  }
-
-  async payBolt11Invoice(
-    invoice: string,
-    extraMeta: JSONObject = {},
-  ): Promise<OutgoingLightningPayment> {
-    await this.updateGatewayCache()
-    const gateway = await this._getDefaultGatewayInfo()
-    return await this._rpcSingle('ln', 'pay_bolt11_invoice', {
-      maybe_gateway: gateway.info,
-      invoice,
-      extra_meta: extraMeta,
-    })
-  }
-
-  subscribeLnPay(
-    operationId: string,
-    onSuccess: (state: LnPayState) => void = () => {},
-    onError: (error: string) => void = () => {},
-  ) {
-    const unsubscribe = this._rpcStream(
-      'ln',
-      'subscribe_ln_pay',
-      { operation_id: operationId },
-      onSuccess,
-      onError,
-    )
-
-    return unsubscribe
-  }
-
-  subscribeLnReceive(
-    operationId: string,
-    onSuccess: (state: LnReceiveState) => void = () => {},
-    onError: (error: string) => void = () => {},
-  ) {
-    const unsubscribe = this._rpcStream(
-      'ln',
-      'subscribe_ln_receive',
-      { operation_id: operationId },
-      onSuccess,
-      onError,
-    )
-
-    return unsubscribe
-  }
-
-  async getGateway(
-    gatewayId: string | null = null,
-    forceInternal: boolean = false,
-  ): Promise<LightningGateway | null> {
-    return await this._rpcSingle('ln', 'get_gateway', {
-      gateway_id: gatewayId,
-      force_internal: forceInternal,
-    })
-  }
-
-  async listGateways(): Promise<LightningGateway[]> {
-    return await this._rpcSingle('ln', 'list_gateways', {})
-  }
-
-  async updateGatewayCache(): Promise<JSONValue> {
-    return await this._rpcSingle('ln', 'update_gateway_cache', {})
+    return this._isOpen
   }
 }

--- a/packages/core-web/src/services/BalanceService.ts
+++ b/packages/core-web/src/services/BalanceService.ts
@@ -1,0 +1,24 @@
+import { WorkerClient } from '../transport'
+
+export class BalanceService {
+  constructor(private client: WorkerClient) {}
+
+  async getBalance(): Promise<number> {
+    return await this.client.rpcSingle('', 'get_balance', {})
+  }
+
+  subscribeBalance(
+    onSuccess: (balance: number) => void = () => {},
+    onError: (error: string) => void = () => {},
+  ) {
+    const unsubscribe = this.client.rpcStream<string>(
+      '',
+      'subscribe_balance_changes',
+      {},
+      (res) => onSuccess(parseInt(res)),
+      onError,
+    )
+
+    return unsubscribe
+  }
+}

--- a/packages/core-web/src/services/FederationService.ts
+++ b/packages/core-web/src/services/FederationService.ts
@@ -1,0 +1,32 @@
+import { JSONValue } from '../types/wallet'
+import { WorkerClient } from '../transport'
+
+export class FederationService {
+  constructor(private client: WorkerClient) {}
+
+  async getConfig(): Promise<JSONValue> {
+    return await this.client.rpcSingle('', 'get_config', {})
+  }
+
+  async getFederationId(): Promise<string> {
+    return await this.client.rpcSingle('', 'get_federation_id', {})
+  }
+
+  async getInviteCode(peer: number): Promise<string | null> {
+    return await this.client.rpcSingle('', 'get_invite_code', { peer })
+  }
+
+  async joinFederation(inviteCode: string, clientName: string): Promise<void> {
+    const response = await this.client.sendSingleMessage('join', {
+      inviteCode,
+      clientName,
+    })
+    if (!response.success) {
+      throw new Error('Failed to join federation')
+    }
+  }
+
+  async listOperations(): Promise<JSONValue[]> {
+    return await this.client.rpcSingle('', 'list_operations', {})
+  }
+}

--- a/packages/core-web/src/services/LightningService.ts
+++ b/packages/core-web/src/services/LightningService.ts
@@ -1,5 +1,3 @@
-// services/LightningService.ts
-
 import { WorkerClient } from '../transport'
 import {
   CreateBolt11Response,

--- a/packages/core-web/src/services/LightningService.ts
+++ b/packages/core-web/src/services/LightningService.ts
@@ -1,0 +1,130 @@
+// services/LightningService.ts
+
+import { WorkerClient } from '../transport'
+import {
+  CreateBolt11Response,
+  GatewayInfo,
+  JSONObject,
+  JSONValue,
+  LightningGateway,
+  LnPayState,
+  LnReceiveState,
+  OutgoingLightningPayment,
+} from '../types/wallet'
+
+export class LightningService {
+  constructor(private client: WorkerClient) {}
+
+  async createBolt11InvoiceWithGateway(
+    amount: number,
+    description: string,
+    expiryTime: number | null = null,
+    extraMeta: JSONObject = {},
+    gatewayInfo: GatewayInfo,
+  ) {
+    return await this.client.rpcSingle('ln', 'create_bolt11_invoice', {
+      amount,
+      description,
+      expiry_time: expiryTime,
+      extra_meta: extraMeta,
+      gateway: gatewayInfo,
+    })
+  }
+
+  async createBolt11Invoice(
+    amount: number,
+    description: string,
+    expiryTime: number | null = null,
+    extraMeta: JSONObject = {},
+  ): Promise<CreateBolt11Response> {
+    await this.updateGatewayCache()
+    const gateway = await this._getDefaultGatewayInfo()
+    return await this.client.rpcSingle('ln', 'create_bolt11_invoice', {
+      amount,
+      description,
+      expiry_time: expiryTime,
+      extra_meta: extraMeta,
+      gateway: gateway.info,
+    })
+  }
+
+  async payBolt11InvoiceWithGateway(
+    invoice: string,
+    gatewayInfo: GatewayInfo,
+    extraMeta: JSONObject = {},
+  ) {
+    return await this.client.rpcSingle('ln', 'pay_bolt11_invoice', {
+      maybe_gateway: gatewayInfo,
+      invoice,
+      extra_meta: extraMeta,
+    })
+  }
+
+  async _getDefaultGatewayInfo(): Promise<LightningGateway> {
+    const gateways = await this.listGateways()
+    return gateways[0]
+  }
+
+  async payBolt11Invoice(
+    invoice: string,
+    extraMeta: JSONObject = {},
+  ): Promise<OutgoingLightningPayment> {
+    await this.updateGatewayCache()
+    const gateway = await this._getDefaultGatewayInfo()
+    return await this.client.rpcSingle('ln', 'pay_bolt11_invoice', {
+      maybe_gateway: gateway.info,
+      invoice,
+      extra_meta: extraMeta,
+    })
+  }
+
+  subscribeLnPay(
+    operationId: string,
+    onSuccess: (state: LnPayState) => void = () => {},
+    onError: (error: string) => void = () => {},
+  ) {
+    const unsubscribe = this.client.rpcStream(
+      'ln',
+      'subscribe_ln_pay',
+      { operation_id: operationId },
+      onSuccess,
+      onError,
+    )
+
+    return unsubscribe
+  }
+
+  subscribeLnReceive(
+    operationId: string,
+    onSuccess: (state: LnReceiveState) => void = () => {},
+    onError: (error: string) => void = () => {},
+  ) {
+    const unsubscribe = this.client.rpcStream(
+      'ln',
+      'subscribe_ln_receive',
+      { operation_id: operationId },
+      onSuccess,
+      onError,
+    )
+
+    return unsubscribe
+  }
+
+  async getGateway(
+    gatewayId: string | null = null,
+    forceInternal: boolean = false,
+  ): Promise<LightningGateway | null> {
+    return await this.client.rpcSingle('ln', 'get_gateway', {
+      gateway_id: gatewayId,
+      force_internal: forceInternal,
+    })
+  }
+
+  async listGateways(): Promise<LightningGateway[]> {
+    return await this.client.rpcSingle('ln', 'list_gateways', {})
+  }
+
+  async updateGatewayCache(): Promise<JSONValue> {
+    return await this.client.rpcSingle('ln', 'update_gateway_cache', {})
+  }
+}

--- a/packages/core-web/src/services/MintService.ts
+++ b/packages/core-web/src/services/MintService.ts
@@ -1,0 +1,93 @@
+import { WorkerClient } from '../transport'
+import { JSONObject, JSONValue } from '../types/wallet'
+
+export class MintService {
+  constructor(private client: WorkerClient) {}
+
+  async redeemEcash(notes: string): Promise<void> {
+    await this.client.rpcSingle('mint', 'reissue_external_notes', {
+      oob_notes: notes, // "out of band notes"
+      extra_meta: null,
+    })
+  }
+
+  async reissueExternalNotes(
+    oobNotes: string,
+    extraMeta: JSONObject,
+  ): Promise<string> {
+    return await this.client.rpcSingle('mint', 'reissue_external_notes', {
+      oob_notes: oobNotes,
+      extra_meta: extraMeta,
+    })
+  }
+
+  subscribeReissueExternalNotes(
+    operationId: string,
+    onSuccess: (state: JSONValue) => void = () => {},
+    onError: (error: string) => void = () => {},
+  ) {
+    type ReissueExternalNotesState =
+      | 'Created'
+      | 'Issuing'
+      | 'Done'
+      | { Failed: { error: string } }
+
+    const unsubscribe = this.client.rpcStream<ReissueExternalNotesState>(
+      'mint',
+      'subscribe_reissue_external_notes',
+      { operation_id: operationId },
+      onSuccess,
+      onError,
+    )
+
+    return unsubscribe
+  }
+
+  async spendNotes(
+    minAmount: number,
+    tryCancelAfter: number,
+    includeInvite: boolean,
+    extraMeta: JSONValue,
+  ): Promise<JSONValue> {
+    return await this.client.rpcSingle('mint', 'spend_notes', {
+      min_amount: minAmount,
+      try_cancel_after: tryCancelAfter,
+      include_invite: includeInvite,
+      extra_meta: extraMeta,
+    })
+  }
+
+  async validateNotes(oobNotes: string): Promise<number> {
+    return await this.client.rpcSingle('mint', 'validate_notes', {
+      oob_notes: oobNotes,
+    })
+  }
+
+  async tryCancelSpendNotes(operationId: string): Promise<void> {
+    await this.client.rpcSingle('mint', 'try_cancel_spend_notes', {
+      operation_id: operationId,
+    })
+  }
+
+  subscribeSpendNotes(
+    operationId: string,
+    onSuccess: (state: JSONValue) => void = () => {},
+    onError: (error: string) => void = () => {},
+  ) {
+    const unsubscribe = this.client.rpcStream(
+      'mint',
+      'subscribe_spend_notes',
+      { operation_id: operationId },
+      (res) => onSuccess(res),
+      onError,
+    )
+
+    return unsubscribe
+  }
+
+  async awaitSpendOobRefund(operationId: string): Promise<JSONValue> {
+    return await this.client.rpcSingle('mint', 'await_spend_oob_refund', {
+      operation_id: operationId,
+    })
+  }
+}

--- a/packages/core-web/src/services/RecoveryService.ts
+++ b/packages/core-web/src/services/RecoveryService.ts
@@ -1,0 +1,26 @@
+import { JSONValue } from '../types/wallet'
+import { WorkerClient } from '../transport'
+
+export class RecoveryService {
+  constructor(private client: WorkerClient) {}
+
+  async hasPendingRecoveries(): Promise<boolean> {
+    return await this.client.rpcSingle('', 'has_pending_recoveries', {})
+  }
+
+  async waitForAllRecoveries(): Promise<void> {
+    await this.client.rpcSingle('', 'wait_for_all_recoveries', {})
+  }
+
+  subscribeToRecoveryProgress(
+    onSuccess: (progress: { module_id: number; progress: JSONValue }) => void,
+    onError: (error: string) => void,
+  ): () => void {
+    const unsubscribe = this.client.rpcStream<{
+      module_id: number
+      progress: JSONValue
+    }>('', 'subscribe_to_recovery_progress', {}, onSuccess, onError)
+
+    return unsubscribe
+  }
+}

--- a/packages/core-web/src/services/index.ts
+++ b/packages/core-web/src/services/index.ts
@@ -1,0 +1,5 @@
+export { MintService } from './MintService'
+export { BalanceService } from './BalanceService'
+export { LightningService } from './LightningService'
+export { RecoveryService } from './RecoveryService'
+export { FederationService } from './FederationService'

--- a/packages/core-web/src/transport/WorkerClient.ts
+++ b/packages/core-web/src/transport/WorkerClient.ts
@@ -1,0 +1,187 @@
+import {
+  CancelFunction,
+  JSONValue,
+  ModuleKind,
+  StreamError,
+  StreamResult,
+} from '../types/wallet'
+
+// Handles communication with the wasm worker
+// TODO: Move rpc stream management to a separate "SubscriptionManager" class
+export class WorkerClient {
+  private worker: Worker
+  private requestCounter = 0
+  private requestCallbacks = new Map<number, (value: any) => void>()
+  private initPromise: Promise<void> | null = null
+
+  constructor(workerUrl: URL) {
+    this.worker = new Worker(workerUrl, { type: 'module' })
+    this.worker.onmessage = this.handleWorkerMessage.bind(this)
+    this.worker.onerror = this.handleWorkerError.bind(this)
+  }
+
+  // Idempotent setup - Loads the wasm module
+  initialize() {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.sendSingleMessage('init')
+    return this.initPromise
+  }
+
+  private handleWorkerError(event: ErrorEvent) {
+    console.error('Worker error', event)
+  }
+
+  private handleWorkerMessage(event: MessageEvent) {
+    const { type, requestId, ...data } = event.data
+    const streamCallback = this.requestCallbacks.get(requestId)
+    // TODO: Handle errors... maybe have another callbacks list for errors?
+    if (streamCallback) {
+      streamCallback(data) // {data: something} OR {error: something}
+    }
+  }
+
+  // TODO: Handle errors... maybe have another callbacks list for errors?
+  // TODO: Handle timeouts
+  // TODO: Handle multiple errors
+
+  sendSingleMessage(type: string, payload?: any): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const requestId = ++this.requestCounter
+      this.requestCallbacks.set(requestId, (response) => {
+        this.requestCallbacks.delete(requestId)
+        if (response.data) resolve(response.data)
+        else if (response.error) reject(response.error)
+      })
+      this.worker.postMessage({ type, payload, requestId })
+    })
+  }
+
+  /**
+   * @summary Initiates an RPC stream with the specified module and method.
+   *
+   * @description
+   * This function sets up an RPC stream by sending a request to a worker and
+   * handling responses asynchronously. It ensures that unsubscription is handled
+   * correctly, even if the unsubscribe function is called before the subscription
+   * is fully established, by deferring the unsubscription attempt using `setTimeout`.
+   *
+   * The function operates in a non-blocking manner, leveraging Promises to manage
+   * asynchronous operations and callbacks to handle responses.
+   *
+   *
+   * @template Response - The expected type of the successful response.
+   * @template Body - The type of the request body.
+   * @param module - The module kind to interact with.
+   * @param method - The method name to invoke on the module.
+   * @param body - The request payload.
+   * @param onSuccess - Callback invoked with the response data on success.
+   * @param onError - Callback invoked with error information if an error occurs.
+   * @param onEnd - Optional callback invoked when the stream ends.
+   * @returns A function that can be called to cancel the subscription.
+   *
+   */
+  rpcStream<
+    Response extends JSONValue = JSONValue,
+    Body extends JSONValue = JSONValue,
+  >(
+    module: ModuleKind,
+    method: string,
+    body: Body,
+    onSuccess: (res: Response) => void,
+    onError: (res: StreamError['error']) => void,
+    onEnd: () => void = () => {},
+  ): CancelFunction {
+    const requestId = ++this.requestCounter
+
+    let unsubscribe: (value: void) => void = () => {}
+    let isSubscribed = false
+
+    const unsubscribePromise = new Promise<void>((resolve) => {
+      unsubscribe = () => {
+        if (isSubscribed) {
+          // If already subscribed, resolve immediately to trigger unsubscription
+          resolve()
+        } else {
+          // If not yet subscribed, defer the unsubscribe attempt to the next event loop tick
+          // This ensures that subscription setup has time to complete
+          setTimeout(() => unsubscribe(), 0)
+        }
+      }
+    })
+
+    // Initiate the inner RPC stream setup asynchronously
+    this._rpcStreamInner(
+      requestId,
+      module,
+      method,
+      body,
+      onSuccess,
+      onError,
+      onEnd,
+      unsubscribePromise,
+    ).then(() => {
+      isSubscribed = true
+    })
+
+    return unsubscribe
+  }
+
+  private async _rpcStreamInner<
+    Response extends JSONValue = JSONValue,
+    Body extends JSONValue = JSONValue,
+  >(
+    requestId: number,
+    module: ModuleKind,
+    method: string,
+    body: Body,
+    onSuccess: (res: Response) => void,
+    onError: (res: StreamError['error']) => void,
+    onEnd: () => void = () => {},
+    unsubscribePromise: Promise<void>,
+    // Unsubscribe function
+  ): Promise<void> {
+    // await this.openPromise
+    // if (!this.worker || !this._isOpen)
+    //   throw new Error('FedimintWallet is not open')
+
+    this.requestCallbacks.set(requestId, (response: StreamResult<Response>) => {
+      if (response.error !== undefined) {
+        onError(response.error)
+      } else if (response.data !== undefined) {
+        onSuccess(response.data)
+      } else if (response.end !== undefined) {
+        this.requestCallbacks.delete(requestId)
+        onEnd()
+      }
+    })
+    this.worker.postMessage({
+      type: 'rpc',
+      payload: { module, method, body },
+      requestId,
+    })
+
+    unsubscribePromise.then(() => {
+      this.worker?.postMessage({
+        type: 'unsubscribe',
+        requestId,
+      })
+      this.requestCallbacks.delete(requestId)
+    })
+  }
+
+  rpcSingle<Response extends JSONValue = JSONValue>(
+    module: ModuleKind,
+    method: string,
+    body: JSONValue,
+  ): Promise<Response> {
+    return new Promise((resolve, reject) => {
+      this.rpcStream<Response>(module, method, body, resolve, reject)
+    })
+  }
+
+  cleanup() {
+    this.worker.terminate()
+    this.initPromise = null
+    this.requestCallbacks.clear()
+  }
+}

--- a/packages/core-web/src/transport/index.ts
+++ b/packages/core-web/src/transport/index.ts
@@ -1,0 +1,1 @@
+export { WorkerClient } from './WorkerClient'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
       include: ['packages/**/*.ts'],
     },
   },
+  optimizeDeps: {
+    exclude: ['@fedimint/core-web'],
+  },
 })


### PR DESCRIPTION
The FedimintWallet was getting pretty beefy, so this refactor should make the core-web package more manageable & testable. In addition, this structure will make it way easier to organize documentation of the feature set.

* Created Services for each category of functionality:
  * Mint Service
  * Lightning Service
  * Balance Service
  * Federation Service
  * Recovery Service
* Moved complex web-worker logic to it's own "Worker Client"
  * TODO: split up subscription logic into a "subscription" or "rpc" client