### PR TITLE
chore: declare worker message types

### DIFF
--- a/.changeset/nervous-beans-chew.md
+++ b/.changeset/nervous-beans-chew.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core-web': patch
+---
+
+declare worker message types

--- a/packages/core-web/src/FedimintWallet.ts
+++ b/packages/core-web/src/FedimintWallet.ts
@@ -1,4 +1,4 @@
-import { WorkerClient } from './worker/WorkerClient'
+import { WorkerClient, WorkerMessageType } from './worker'
 import {
   BalanceService,
   MintService,
@@ -85,9 +85,12 @@ export class FedimintWallet {
     await this._client.initialize()
     // TODO: Determine if this should be safe or throw
     if (this._isOpen) throw new Error('The FedimintWallet is already open.')
-    const { success } = await this._client.sendSingleMessage('open', {
-      clientName,
-    })
+    const { success } = await this._client.sendSingleMessage(
+      WorkerMessageType.Open,
+      {
+        clientName,
+      },
+    )
     if (success) {
       this._isOpen = !!success
       this._resolveOpen()
@@ -105,10 +108,13 @@ export class FedimintWallet {
       throw new Error(
         'The FedimintWallet is already open. You can only call `joinFederation` on closed clients.',
       )
-    const response = await this._client.sendSingleMessage('join', {
-      inviteCode,
-      clientName,
-    })
+    const response = await this._client.sendSingleMessage(
+      WorkerMessageType.Join,
+      {
+        inviteCode,
+        clientName,
+      },
+    )
     if (response.success) {
       this._isOpen = true
       this._resolveOpen()

--- a/packages/core-web/src/index.ts
+++ b/packages/core-web/src/index.ts
@@ -1,16 +1,4 @@
-import { FedimintWallet } from './FedimintWallet.js'
-import {
-  LightningGateway,
-  RouteHint,
-  FeeToAmount,
-  OutgoingLightningPayment,
-  PayType,
-  LnPayState,
-  CreateBolt11Response,
-} from './types/wallet.js'
-
-export { FedimintWallet }
-
+export { FedimintWallet } from './FedimintWallet'
 export type {
   LightningGateway,
   RouteHint,
@@ -19,4 +7,4 @@ export type {
   PayType,
   LnPayState,
   CreateBolt11Response,
-}
+} from './types/wallet'

--- a/packages/core-web/src/worker/index.ts
+++ b/packages/core-web/src/worker/index.ts
@@ -1,1 +1,2 @@
+export { WorkerMessageType } from './types'
 export { WorkerClient } from './WorkerClient'

--- a/packages/core-web/src/worker/types.ts
+++ b/packages/core-web/src/worker/types.ts
@@ -1,0 +1,10 @@
+export enum WorkerMessageType {
+  Init = 'init',
+  Initialized = 'initialized',
+  Rpc = 'rpc',
+  Log = 'log',
+  Open = 'open',
+  Join = 'join',
+  Error = 'error',
+  Unsubscribe = 'unsubscribe',
+}


### PR DESCRIPTION
Quickly found it difficult to keep track of the worker messages, and realized the messages will only grow as components like the wallet are built out. This PR introduces `enum WorkerMessageType` for the purposes of tracking and strong typing messages