### PR TITLE
fix: update default ecash expiry to 1 day

### DIFF
--- a/.changeset/orange-owls-begin.md
+++ b/.changeset/orange-owls-begin.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core-web': patch
+---
+
+Changed default "expiry" for ecash spends to 1 day

--- a/packages/core-web/src/services/MintService.ts
+++ b/packages/core-web/src/services/MintService.ts
@@ -47,10 +47,9 @@ export class MintService {
   async spendNotes(
     minAmount: MSats,
     // Tells the wallet to automatically try to cancel the spend if it hasn't completed
-    // after the specified number of milliseconds.
-    // If the receiver has already redeemed the notes at this time,
-    // the notes will not be cancelled
-    tryCancelAfter: number | Duration = 0, // in seconds or Duration object
+    // after the specified number of seconds. If the receiver has already redeemed
+    // the notes at this time, the notes will not be cancelled.
+    tryCancelAfter: number | Duration = 3600 * 24, // defaults to 1 day
     includeInvite: boolean = false,
     extraMeta: JSONValue = {},
   ): Promise<MintSpendNotesResponse> {


### PR DESCRIPTION
This pull request changes the default "expiry" for ecash spends and adjusting the `tryCancelAfter` parameter in the `MintService`.

### Updates to `MintService`:

* [`packages/core-web/src/services/MintService.ts`](diffhunk://#diff-495e82e4c4aee23c5855e8135c9aeffc9955eb42e7ba678e7681f69d63a67ef8L50-R52): Updated the `tryCancelAfter` parameter in the `spendNotes` method to default to 1 day (3600 * 24 seconds).