### PR TITLE
fix: PayType

### DIFF
--- a/.changeset/little-peaches-happen.md
+++ b/.changeset/little-peaches-happen.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core-web': patch
+---
+
+Fix PayType

--- a/packages/core-web/src/types/wallet.ts
+++ b/packages/core-web/src/types/wallet.ts
@@ -30,10 +30,7 @@ type OutgoingLightningPayment = {
   fee: MSats
 }
 
-type PayType = {
-  type: 'Internal' | 'Lightning'
-  operation_id: string
-}
+type PayType = { lightning: string } | { internal: string }
 
 type LnPayState =
   | 'created'


### PR DESCRIPTION
Makes `PayType` match what is returned by payLightningInvoice