### PR TITLE
chore: use buildjet for heavy CI job

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -54,7 +54,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
I wasn't able to figure out how to run it on our self-hosted NixOS runner (#81), so this is a good stop-gap solution.