### PR TITLE
chore: fixes package.json breaking react example

### DIFF
--- a/examples/vite-core/package.json
+++ b/examples/vite-core/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fedimint/core-web": "^0.0.10",
-    "react": "^18.3.1",
+    "react": ">=18.3.1",
     "react-dom": ">=18.3.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         specifier: ^0.0.10
         version: 0.0.10
       react:
-        specifier: ^18.3.1
+        specifier: '>=18.3.1'
         version: 18.3.1
       react-dom:
         specifier: '>=18.3.1'


### PR DESCRIPTION
The react example wasn't building locally and at https://web.fedimint.org/examples/vite-react.html via StackBlitz