### PR TITLE
chore: update fedimint version in devtools to 0.6.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,12 +20,7 @@
       "inputs": {
         "devshell": "devshell",
         "flake-utils": "flake-utils_3",
-        "nixpkgs": [
-          "fedimint",
-          "cargo-deluxe",
-          "flakebox",
-          "nixpkgs"
-        ]
+        "nixpkgs": ["fedimint", "cargo-deluxe", "flakebox", "nixpkgs"]
       },
       "locked": {
         "lastModified": 1727381935,
@@ -46,11 +41,7 @@
       "inputs": {
         "devshell": "devshell_2",
         "flake-utils": "flake-utils_7",
-        "nixpkgs": [
-          "fedimint",
-          "flakebox",
-          "nixpkgs"
-        ]
+        "nixpkgs": ["fedimint", "flakebox", "nixpkgs"]
       },
       "locked": {
         "lastModified": 1732566114,
@@ -71,10 +62,7 @@
       "inputs": {
         "nix-bundle": "nix-bundle",
         "nix-utils": "nix-utils",
-        "nixpkgs": [
-          "fedimint",
-          "nixpkgs"
-        ]
+        "nixpkgs": ["fedimint", "nixpkgs"]
       },
       "locked": {
         "lastModified": 1729104746,
@@ -95,10 +83,7 @@
       "inputs": {
         "flake-utils": "flake-utils_2",
         "flakebox": "flakebox",
-        "nixpkgs": [
-          "fedimint",
-          "nixpkgs"
-        ]
+        "nixpkgs": ["fedimint", "nixpkgs"]
       },
       "locked": {
         "lastModified": 1729202329,
@@ -117,12 +102,7 @@
     },
     "crane": {
       "inputs": {
-        "nixpkgs": [
-          "fedimint",
-          "cargo-deluxe",
-          "flakebox",
-          "nixpkgs"
-        ]
+        "nixpkgs": ["fedimint", "cargo-deluxe", "flakebox", "nixpkgs"]
       },
       "locked": {
         "lastModified": 1717383740,
@@ -141,11 +121,7 @@
     },
     "crane_2": {
       "inputs": {
-        "nixpkgs": [
-          "fedimint",
-          "flakebox",
-          "nixpkgs"
-        ]
+        "nixpkgs": ["fedimint", "flakebox", "nixpkgs"]
       },
       "locked": {
         "lastModified": 1717383740,
@@ -190,12 +166,7 @@
     "devshell_2": {
       "inputs": {
         "flake-utils": "flake-utils_6",
-        "nixpkgs": [
-          "fedimint",
-          "flakebox",
-          "android-nixpkgs",
-          "nixpkgs"
-        ]
+        "nixpkgs": ["fedimint", "flakebox", "android-nixpkgs", "nixpkgs"]
       },
       "locked": {
         "lastModified": 1717408969,
@@ -239,12 +210,7 @@
     },
     "fenix": {
       "inputs": {
-        "nixpkgs": [
-          "fedimint",
-          "cargo-deluxe",
-          "flakebox",
-          "nixpkgs"
-        ],
+        "nixpkgs": ["fedimint", "cargo-deluxe", "flakebox", "nixpkgs"],
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
@@ -263,10 +229,7 @@
     },
     "fenix_2": {
       "inputs": {
-        "nixpkgs": [
-          "fedimint",
-          "nixpkgs"
-        ],
+        "nixpkgs": ["fedimint", "nixpkgs"],
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
@@ -336,12 +299,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": [
-          "fedimint",
-          "cargo-deluxe",
-          "flakebox",
-          "systems"
-        ]
+        "systems": ["fedimint", "cargo-deluxe", "flakebox", "systems"]
       },
       "locked": {
         "lastModified": 1694529238,
@@ -413,11 +371,7 @@
     },
     "flake-utils_8": {
       "inputs": {
-        "systems": [
-          "fedimint",
-          "flakebox",
-          "systems"
-        ]
+        "systems": ["fedimint", "flakebox", "systems"]
       },
       "locked": {
         "lastModified": 1710146030,
@@ -478,15 +432,9 @@
       "inputs": {
         "android-nixpkgs": "android-nixpkgs_2",
         "crane": "crane_2",
-        "fenix": [
-          "fedimint",
-          "fenix"
-        ],
+        "fenix": ["fedimint", "fenix"],
         "flake-utils": "flake-utils_8",
-        "nixpkgs": [
-          "fedimint",
-          "nixpkgs"
-        ],
+        "nixpkgs": ["fedimint", "nixpkgs"],
         "systems": "systems_9"
       },
       "locked": {

--- a/flake.lock
+++ b/flake.lock
@@ -19,21 +19,51 @@
     "android-nixpkgs": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": ["fedimint", "flakebox", "nixpkgs"]
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "fedimint",
+          "cargo-deluxe",
+          "flakebox",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1719001124,
-        "narHash": "sha256-JXrMwYlQarZPyjN5UkD4fS9mrHSE1PUa7P//1Z5Sqr0=",
+        "lastModified": 1727381935,
+        "narHash": "sha256-G2fOYRZM7bXK5eBb+GK3k/WmO+q5JA/GtFwSPc3kdc8=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "7fa1348249564e43185d3053f579f9fa923d46cc",
+        "rev": "522d86121cbd413aff922c54f38106ecf8740107",
         "type": "github"
       },
       "original": {
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "7fa1348249564e43185d3053f579f9fa923d46cc",
+        "rev": "522d86121cbd413aff922c54f38106ecf8740107",
+        "type": "github"
+      }
+    },
+    "android-nixpkgs_2": {
+      "inputs": {
+        "devshell": "devshell_2",
+        "flake-utils": "flake-utils_7",
+        "nixpkgs": [
+          "fedimint",
+          "flakebox",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1732566114,
+        "narHash": "sha256-rgFf/qq7vR4KKRfZ55jnWN+d7WjE8Qhz6BYywsbD79w=",
+        "owner": "tadfisher",
+        "repo": "android-nixpkgs",
+        "rev": "4ecd9e0da0a955a180a429196f59a8716d1dd138",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tadfisher",
+        "repo": "android-nixpkgs",
+        "rev": "4ecd9e0da0a955a180a429196f59a8716d1dd138",
         "type": "github"
       }
     },
@@ -41,26 +71,81 @@
       "inputs": {
         "nix-bundle": "nix-bundle",
         "nix-utils": "nix-utils",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": [
+          "fedimint",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1708548996,
-        "narHash": "sha256-U7DF6oLGaGm4SmfUnaK8X2Y36fprVd7EFr8sqV6Ocp8=",
-        "owner": "dpc",
+        "lastModified": 1729104746,
+        "narHash": "sha256-7K+dlB8JPT/HD8wcnbb+BV3kFllnBQ6jpXtJX6wmDPk=",
+        "owner": "NixOS",
         "repo": "bundlers",
-        "rev": "e8aafe89a11ae0a5f3ce97d1d7d0fcfb354c79eb",
+        "rev": "ea1e72ad1dbb0864fd55b3ba52ed166cd190afa2",
         "type": "github"
       },
       "original": {
-        "owner": "dpc",
+        "owner": "NixOS",
         "repo": "bundlers",
-        "rev": "e8aafe89a11ae0a5f3ce97d1d7d0fcfb354c79eb",
+        "rev": "ea1e72ad1dbb0864fd55b3ba52ed166cd190afa2",
+        "type": "github"
+      }
+    },
+    "cargo-deluxe": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "flakebox": "flakebox",
+        "nixpkgs": [
+          "fedimint",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729202329,
+        "narHash": "sha256-lltxyfay1Vg1CmcAU/r3kOCQs7/WdK22YKORAgzmXkg=",
+        "owner": "rustshop",
+        "repo": "cargo-deluxe",
+        "rev": "4acc6488d02f032434a5a1341f21f20d328bba40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustshop",
+        "repo": "cargo-deluxe",
+        "rev": "4acc6488d02f032434a5a1341f21f20d328bba40",
         "type": "github"
       }
     },
     "crane": {
       "inputs": {
-        "nixpkgs": ["fedimint", "flakebox", "nixpkgs"]
+        "nixpkgs": [
+          "fedimint",
+          "cargo-deluxe",
+          "flakebox",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717383740,
+        "narHash": "sha256-559HbY4uhNeoYvK3H6AMZAtVfmR3y8plXZ1x6ON/cWU=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "b65673fce97d277934488a451724be94cc62499a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "b65673fce97d277934488a451724be94cc62499a",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "inputs": {
+        "nixpkgs": [
+          "fedimint",
+          "flakebox",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1717383740,
@@ -79,8 +164,38 @@
     },
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": ["fedimint", "flakebox", "android-nixpkgs", "nixpkgs"]
+        "nixpkgs": [
+          "fedimint",
+          "cargo-deluxe",
+          "flakebox",
+          "android-nixpkgs",
+          "nixpkgs"
+        ],
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1695195896,
+        "narHash": "sha256-pq9q7YsGXnQzJFkR5284TmxrLNFc0wo4NQ/a5E93CQU=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "05d40d17bf3459606316e3e9ec683b784ff28f16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": [
+          "fedimint",
+          "flakebox",
+          "android-nixpkgs",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1717408969,
@@ -100,30 +215,59 @@
       "inputs": {
         "advisory-db": "advisory-db",
         "bundlers": "bundlers",
-        "fenix": "fenix",
-        "flake-utils": "flake-utils_2",
-        "flakebox": "flakebox",
-        "nixpkgs": "nixpkgs_4"
+        "cargo-deluxe": "cargo-deluxe",
+        "fenix": "fenix_2",
+        "flake-utils": "flake-utils_5",
+        "flakebox": "flakebox_2",
+        "nixpkgs": "nixpkgs_4",
+        "nixpkgs-old": "nixpkgs-old"
       },
       "locked": {
-        "lastModified": 1727317398,
-        "narHash": "sha256-NUr1ZpYJozWIej46Oqlf/7feJ4kztYYvX3TEzQ5VoWo=",
+        "lastModified": 1741280062,
+        "narHash": "sha256-BHSsjMZYRuBng8vfZew1dkGoPU/l0WWdiDSqKm2plUY=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "1813069d5d18a29f611a423990e8013a7331d2a2",
+        "rev": "55a144e5592fd5dc77997743e24ed414aac14e31",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
-        "ref": "v0.4.3",
+        "ref": "v0.6.1",
         "repo": "fedimint",
         "type": "github"
       }
     },
     "fenix": {
       "inputs": {
-        "nixpkgs": ["fedimint", "nixpkgs"],
+        "nixpkgs": [
+          "fedimint",
+          "cargo-deluxe",
+          "flakebox",
+          "nixpkgs"
+        ],
         "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1696918968,
+        "narHash": "sha256-18rAHsM9YsGp7aKKemO4gKIeWfrSyDsdJZ/mk4dQ3JI=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "638fc95a2a3d01b372c76f71cbb6d73c63909d6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "fedimint",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
         "lastModified": 1727245890,
@@ -156,7 +300,66 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": [
+          "fedimint",
+          "cargo-deluxe",
+          "flakebox",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1726560853,
@@ -172,9 +375,9 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_6": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -190,9 +393,9 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_7": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -208,9 +411,13 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_8": {
       "inputs": {
-        "systems": ["fedimint", "flakebox", "systems"]
+        "systems": [
+          "fedimint",
+          "flakebox",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1710146030,
@@ -226,9 +433,9 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
+    "flake-utils_9": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1726560853,
@@ -248,42 +455,71 @@
       "inputs": {
         "android-nixpkgs": "android-nixpkgs",
         "crane": "crane",
-        "fenix": ["fedimint", "fenix"],
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": ["fedimint", "nixpkgs"],
-        "systems": "systems_4"
+        "fenix": "fenix",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_3",
+        "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1719004469,
-        "narHash": "sha256-TZSHiEJ3qYgA46vikQKT2bwGCEF2LrJVw7cettqa+/g=",
+        "lastModified": 1728662483,
+        "narHash": "sha256-phVyjjgVmHFUF6+DGFRA+1fCV0zs8ipwRn/M33LtIYY=",
+        "owner": "rustshop",
+        "repo": "flakebox",
+        "rev": "1a65534520d8a592fd7d75f7db18cfed40fa5c09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustshop",
+        "repo": "flakebox",
+        "type": "github"
+      }
+    },
+    "flakebox_2": {
+      "inputs": {
+        "android-nixpkgs": "android-nixpkgs_2",
+        "crane": "crane_2",
+        "fenix": [
+          "fedimint",
+          "fenix"
+        ],
+        "flake-utils": "flake-utils_8",
+        "nixpkgs": [
+          "fedimint",
+          "nixpkgs"
+        ],
+        "systems": "systems_9"
+      },
+      "locked": {
+        "lastModified": 1736282508,
+        "narHash": "sha256-IlNjz7jNSoQQSPGaYI0cphbQUMf0DttwQeNO5Kp9X2A=",
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "12d5ee4f6c47bc01f07ec6f5848a83db265902d3",
+        "rev": "56ee87b7dd205c7af169ff72e818e3a92560b424",
         "type": "github"
       },
       "original": {
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "12d5ee4f6c47bc01f07ec6f5848a83db265902d3",
+        "rev": "56ee87b7dd205c7af169ff72e818e3a92560b424",
         "type": "github"
       }
     },
     "nix-bundle": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
       },
       "locked": {
-        "lastModified": 1708548961,
-        "narHash": "sha256-WVA2EMhl/jk5GS84y20ExnIW03UyH43wRuoiySxHGZE=",
-        "owner": "dpc",
+        "lastModified": 1729095141,
+        "narHash": "sha256-2AXV3I8D/I3UkQY797j/fSKrIwbUpTVZ82s2O/ErtVM=",
+        "owner": "matthewbauer",
         "repo": "nix-bundle",
-        "rev": "8ab9acfe0a31805de7899eddb8f3312d4e34a13d",
+        "rev": "4f6330b20767744a4c28788e3cdb05e02d096cd8",
         "type": "github"
       },
       "original": {
-        "owner": "dpc",
+        "owner": "matthewbauer",
         "repo": "nix-bundle",
-        "rev": "8ab9acfe0a31805de7899eddb8f3312d4e34a13d",
         "type": "github"
       }
     },
@@ -308,17 +544,34 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-20.03-small",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-old": {
+      "locked": {
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
@@ -338,29 +591,32 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1634782485,
-        "narHash": "sha256-psfh4OQSokGXG0lpq3zKFbhOo3QfoeudRcaUnwMRkQo=",
-        "path": "/nix/store/p53cz6rh27q40g9i0q98k3vfrz6lm12w-source",
-        "rev": "34ad3ffe08adfca17fcb4e4a47bb5f3b113687be",
-        "type": "path"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1727129439,
-        "narHash": "sha256-nPyrcFm6FSk7CxzVW4x2hu62aLDghNcv9dX6DF3dXw8=",
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "babc25a577c3310cce57c72d5bed70f4c3c3843a",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1741445498,
+        "narHash": "sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "52e3095f6d812b91b22fb7ad0bfc1ab416453634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -368,10 +624,27 @@
     "root": {
       "inputs": {
         "fedimint": "fedimint",
-        "flake-utils": "flake-utils_6"
+        "flake-utils": "flake-utils_9"
       }
     },
     "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696840854,
+        "narHash": "sha256-wphOvjDSDsUN5DMe3MOhdargANIab7YE3hkh3Qv7qso=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "aaa1e8e1b82d742b876d164a30dda02f318ce809",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_2": {
       "flake": false,
       "locked": {
         "lastModified": 1727104575,
@@ -389,6 +662,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_10": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -460,6 +748,84 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_8": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_9": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      url = "github:fedimint/fedimint?ref=v0.4.3";
+      url = "github:fedimint/fedimint?ref=v0.6.1";
     };
   };
   outputs = { self, flake-utils, fedimint }:
@@ -11,7 +11,7 @@
         nixpkgs = fedimint.inputs.nixpkgs;
         pkgs = import nixpkgs {
           inherit system;
-          overlays = fedimint.overlays.fedimint;
+          overlays = [fedimint.overlays.all];
         };
         fmLib = fedimint.lib.${system};
       in


### PR DESCRIPTION
Updates  fedimint in dev tools to the newest version 0.6.1
supersedes #116