### PR TITLE
chore: bump test timeout

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,7 +55,7 @@ jobs:
   test:
     name: Test
     runs-on: [self-hosted, linux]
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
We were seeing timeout failures https://github.com/fedimint/fedimint-web-sdk/actions/runs/14977939859/job/42074892204?pr=128