### PR TITLE
fix: renamed min_amount to amount to match rpc in MintService

### DIFF
--- a/packages/core-web/src/services/MintService.ts
+++ b/packages/core-web/src/services/MintService.ts
@@ -70,7 +70,7 @@ export class MintService {
       'mint',
       'spend_notes',
       {
-        min_amount: amountMsats,
+        amount: amountMsats,
         try_cancel_after: duration,
         include_invite: includeInvite,
         extra_meta: extraMeta,


### PR DESCRIPTION
**Context:** While implementing spendNotes its throwing error for not getting amount field in rpc  `RPC response 10 {"error":"missing field amount"}`

Have renamed the min_amount to amount to match the rpc

@alexlwn123 @maan2003 