### PR TITLE
fix: revert example versioning

### DIFF
--- a/examples/bare-js/package.json
+++ b/examples/bare-js/package.json
@@ -1,6 +1,5 @@
 {
   "name": "bare-js",
-  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/next-js/package.json
+++ b/examples/next-js/package.json
@@ -1,6 +1,5 @@
 {
   "name": "next-js",
-  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/vite-core/package.json
+++ b/examples/vite-core/package.json
@@ -1,6 +1,5 @@
 {
   "name": "vite-core",
-  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/webpack-app/package.json
+++ b/examples/webpack-app/package.json
@@ -1,6 +1,5 @@
 {
   "name": "webpack-app",
-  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
reverts https://github.com/fedimint/fedimint-web-sdk/pull/144

Was causing CI failures due to failing to install deps BEFORE the new versions are published. Will just have to manually bump websdk lib versions in the examples after releases for now.