### PR TITLE
chore: Pin version in examples to latest

### DIFF
--- a/examples/next-js/package.json
+++ b/examples/next-js/package.json
@@ -8,7 +8,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@fedimint/core-web": "^0.0.10",
+    "@fedimint/core-web": "latest",
     "next": "15.2.4",
     "react": ">=19.1.0",
     "react-dom": ">=19.1.0"

--- a/examples/vite-core/package.json
+++ b/examples/vite-core/package.json
@@ -10,7 +10,7 @@
     "clean:deep": "pnpm run clean && rm -rf node_modules"
   },
   "dependencies": {
-    "@fedimint/core-web": "^0.0.10",
+    "@fedimint/core-web": "latest",
     "react": ">=19.1.0",
     "react-dom": ">=19.1.0"
   },

--- a/examples/webpack-app/package.json
+++ b/examples/webpack-app/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@fedimint/core-web": "^0.0.10"
+    "@fedimint/core-web": "latest"
   },
   "devDependencies": {
     "@babel/core": "^7.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,7 @@ importers:
   examples/next-js:
     dependencies:
       '@fedimint/core-web':
-        specifier: ^0.0.10
+        specifier: latest
         version: 0.0.10
       next:
         specifier: 15.2.4
@@ -124,7 +124,7 @@ importers:
   examples/vite-core:
     dependencies:
       '@fedimint/core-web':
-        specifier: ^0.0.10
+        specifier: latest
         version: 0.0.10
       react:
         specifier: '>=19.1.0'
@@ -158,7 +158,7 @@ importers:
   examples/webpack-app:
     dependencies:
       '@fedimint/core-web':
-        specifier: ^0.0.10
+        specifier: latest
         version: 0.0.10
     devDependencies:
       '@babel/core':


### PR DESCRIPTION
pinning the version to latest due to changesets breaking on releases. Not super happy about this, but I'm out of ideas.

This is tricky. We need the version bumping to work properly without breaking the stackblitz examples. Typically, we'd use `workspace:*`, but this doesn't work inside of stackblitz. 



