### PR TITLE
feat: Added listTransactions, getOperation and enabled pagination in listOperations

### DIFF
--- a/.changeset/moody-doodles-doubt.md
+++ b/.changeset/moody-doodles-doubt.md
@@ -1,0 +1,7 @@
+---
+'@fedimint/fedimint-client-wasm-bundler': patch
+'@fedimint/core-web': patch
+'@fedimint/fedimint-client-wasm-web': patch
+---
+
+Implemented getOperation method and enabled pagination in listOperations and updated the docs

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -126,6 +126,9 @@ const FedimintWalletSidebar = [
           { text: 'getConfig()', link: 'getConfig' },
           { text: 'getFederationId()', link: 'getFederationId' },
           { text: 'getInviteCode()', link: 'getInviteCode' },
+          { text: 'getOperation()', link: 'getOperation' },
+          { text: 'listOperations()', link: 'listOperations' },
+          { text: 'listTransactions()', link: 'listTransactions' },
         ],
       },
       {

--- a/docs/core/FedimintWallet/FederationService/getOperation.md
+++ b/docs/core/FedimintWallet/FederationService/getOperation.md
@@ -1,0 +1,17 @@
+# Get Operation
+
+### `federation.getOperation(operationId:string)`
+
+Get the transaction data using the operation id.
+
+```ts twoslash
+// @esModuleInterop
+import { FedimintWallet } from '@fedimint/core-web'
+
+const wallet = new FedimintWallet()
+wallet.open()
+
+const operationId =
+  '3ff56b29cf014b9ff6c8b6b4aa78e02d3c429de7112bfaf42a876f6a797ddf8b'
+const config = await wallet.federation.getOperation(operationId)
+```

--- a/docs/core/FedimintWallet/FederationService/listOperations.md
+++ b/docs/core/FedimintWallet/FederationService/listOperations.md
@@ -1,0 +1,21 @@
+# List Operations
+
+### `federation.listOperations(limit?:number,lastseen:lastSeenRequest)`
+
+Returns a paginated list of operations (transactions) from the federation. In case limit and lastseen not given, returns all the available operations.
+
+```ts twoslash
+// @esModuleInterop
+import { FedimintWallet } from '@fedimint/core-web'
+
+const wallet = new FedimintWallet()
+wallet.open()
+
+const limit = 10
+const lastseen = {
+  creation_time: { secs_since_epoch: 2323233, nanos_since_epoch: 93429234 },
+  operation_id:
+    '3ff56b29cf014b9ff6c8b6b4aa78e02d3c429de7112bfaf42a876f6a797ddf8b',
+}
+const operations = await wallet.federation.listOperations(limit, lastseen)
+```

--- a/docs/core/FedimintWallet/FederationService/listTransactions.md
+++ b/docs/core/FedimintWallet/FederationService/listTransactions.md
@@ -1,0 +1,39 @@
+# List Transactions
+
+### `federation.listTransactions(limit?:number,lastseen:lastSeenRequest)`
+
+Returns a paginated list of transactions from the federation. In case limit and lastseen not given, returns all the available transactions.
+
+```ts twoslash
+/**
+ * Represents wallet transaction record.
+ * Includes timestamp, type, amount, and related metadata.
+ */
+export type Transactions = {
+  timeStamp: string
+  paymentType: string
+  type: string
+  amount: string
+  invoice: string
+  operationId: string
+  outcome: string
+  gateway: string
+}
+```
+
+```ts twoslash
+// @esModuleInterop
+import { FedimintWallet } from '@fedimint/core-web'
+
+const wallet = new FedimintWallet()
+wallet.open()
+
+const limit = 10
+const lastseen = {
+  creation_time: { secs_since_epoch: 2323233, nanos_since_epoch: 93429234 },
+  operation_id:
+    '3ff56b29cf014b9ff6c8b6b4aa78e02d3c429de7112bfaf42a876f6a797ddf8b',
+}
+const transactions = await wallet.federation.listTransactions(limit, lastseen)
+console.log('transactions are: ', transactions)
+```

--- a/docs/core/FedimintWallet/type-aliases/lastSeenRequest.md
+++ b/docs/core/FedimintWallet/type-aliases/lastSeenRequest.md
@@ -1,0 +1,37 @@
+[Core Web](../globals.md) / LastSeenRequest
+
+# Type Alias: LastSeenRequest
+
+> **LastSeenRequest**: `object`
+
+Represents a pagination key for fetching operations in `listOperations` method.
+
+## Type Declaration
+
+### creation_time
+
+> **creation_time**: `object`
+
+Timestamp of the operation used as a pagination cursor.
+
+#### secs_since_epoch
+
+> **secs_since_epoch**: `number`
+
+Seconds since the Unix epoch
+
+#### nanos_since_epoch
+
+> **nanos_since_epoch**: `number`
+
+Nanoseconds for sub-second precision
+
+### operation_id
+
+> **operation_id**: `string`
+
+Unique identifier for the operation
+
+## Defined in
+
+[types/wallet.ts:5](https://github.com/fedimint/fedimint-web-sdk/blob/main/packages/core-web/src/types/wallet.ts#122)

--- a/packages/core-web/src/services/FederationService.ts
+++ b/packages/core-web/src/services/FederationService.ts
@@ -1,4 +1,9 @@
-import type { JSONValue } from '../types'
+import type {
+  GetOperationResponse,
+  JSONValue,
+  lastSeenRequest,
+  Transactions,
+} from '../types'
 import { WorkerClient } from '../worker'
 
 export class FederationService {
@@ -18,7 +23,138 @@ export class FederationService {
     })
   }
 
-  async listOperations() {
-    return await this.client.rpcSingle<JSONValue[]>('', 'list_operations', {})
+  async listOperations(
+    limit?: number,
+    last_seen?: lastSeenRequest,
+  ): Promise<JSONValue[]> {
+    return await this.client.rpcSingle<JSONValue[]>('', 'list_operations', {
+      limit: limit ?? null,
+      last_seen: last_seen ?? null,
+    })
+  }
+
+  async getOperation(operationId: string) {
+    return await this.client.rpcSingle<GetOperationResponse>(
+      '',
+      'get_operation',
+      { operation_id: operationId },
+    )
+  }
+
+  async listTransactions(
+    limit?: number,
+    last_seen?: lastSeenRequest,
+  ): Promise<Transactions[]> {
+    const operations = await this.listOperations(limit, last_seen)
+    return operations
+      .filter(
+        (item): item is [any, any] => Array.isArray(item) && item.length === 2,
+      )
+      .filter(([_, op]: [any, any]) => {
+        const moduleKind = op.operation_module_kind
+        const variant = op.meta?.variant || {}
+        return (
+          (moduleKind === 'ln' && (variant.pay || variant.receive)) ||
+          (moduleKind === 'mint' &&
+            (variant.spend_o_o_b || variant.reissuance)) ||
+          (moduleKind === 'wallet' && (variant.deposit || variant.withdraw))
+        )
+      })
+      .map(([key, op]) => {
+        const timeStamp = key.creation_time
+          ? new Date(
+              key.creation_time.secs_since_epoch * 1000 +
+                key.creation_time.nanos_since_epoch / 1_000_000,
+            ).toLocaleString()
+          : '-'
+        const operationId = key.operation_id
+        const moduleKind = op.operation_module_kind
+        let amount = 'N/A'
+        let paymentType = 'unknown'
+        let invoice = 'N/A'
+        const meta = op.meta || {}
+        const variant = meta.variant || {}
+
+        if (moduleKind === 'ln') {
+          paymentType = variant.pay
+            ? 'send'
+            : variant.receive
+              ? 'receive'
+              : 'unknown'
+        } else if (moduleKind === 'mint') {
+          paymentType = variant.spend_o_o_b
+            ? 'spend_oob'
+            : variant.reissuance
+              ? 'reissue'
+              : 'unknown'
+        }
+
+        let outcome: string
+        if (!op.outcome?.outcome) {
+          outcome = 'N/A'
+        } else if (typeof op.outcome.outcome === 'object') {
+          if ('success' in op.outcome.outcome) {
+            outcome = 'success'
+          } else if ('canceled' in op.outcome.outcome) {
+            outcome = 'canceled'
+          } else if ('WaitingForConfirmation' in op.outcome.outcome) {
+            outcome = 'pending'
+          } else if ('Confirmed' in op.outcome.outcome) {
+            outcome = 'confirmed'
+          } else if ('Claimed' in op.outcome.outcome) {
+            outcome = 'claimed'
+          } else {
+            outcome = 'unknown'
+          }
+        } else {
+          outcome = op.outcome.outcome
+        }
+
+        if (moduleKind === 'mint') {
+          if (meta.amount && typeof meta.amount === 'number') {
+            amount = meta.amount.toString()
+          } else if (
+            variant.spend_o_o_b?.requested_amount &&
+            typeof variant.spend_o_o_b.requested_amount === 'number'
+          ) {
+            amount = variant.spend_o_o_b.requested_amount
+          }
+        } else if (moduleKind === 'ln') {
+          invoice = variant.pay?.invoice || variant.receive?.invoice
+        } else if (moduleKind === 'wallet') {
+          if (
+            variant.withdraw?.amount &&
+            typeof variant.withdraw.amount === 'number'
+          ) {
+            amount = variant.withdraw.amount.toString()
+          } else if (op.outcome && typeof op.outcome.outcome === 'object') {
+            const outcome = op.outcome.outcome
+            if (
+              ('WaitingForConfirmation' in outcome &&
+                outcome.WaitingForConfirmation.btc_deposited) ||
+              ('Confirmed' in outcome && outcome.Confirmed.btc_deposited) ||
+              ('Claimed' in outcome && outcome.Claimed.btc_deposited)
+            ) {
+              amount =
+                outcome.WaitingForConfirmation?.btc_deposited ||
+                outcome.Confirmed?.btc_deposited ||
+                outcome.Claimed?.btc_deposited
+            }
+          }
+          paymentType = variant.deposit ? 'deposit' : 'withdraw'
+        }
+
+        return {
+          timeStamp,
+          paymentType,
+          type: moduleKind,
+          amount,
+          invoice,
+          operationId,
+          outcome,
+          gateway:
+            variant.pay?.gateway_id || variant.receive?.gateway_id || 'N/A',
+        }
+      })
   }
 }

--- a/packages/core-web/src/services/FederationService.ts
+++ b/packages/core-web/src/services/FederationService.ts
@@ -1,8 +1,13 @@
 import type {
-  GetOperationResponse,
-  JSONValue,
-  lastSeenRequest,
+  EcashTransaction,
+  LightningTransaction,
+  LnVariant,
+  MintVariant,
+  OperationKey,
+  OperationLog,
   Transactions,
+  WalletTransaction,
+  WalletVariant,
 } from '../types'
 import { WorkerClient } from '../worker'
 
@@ -25,16 +30,20 @@ export class FederationService {
 
   async listOperations(
     limit?: number,
-    last_seen?: lastSeenRequest,
-  ): Promise<JSONValue[]> {
-    return await this.client.rpcSingle<JSONValue[]>('', 'list_operations', {
-      limit: limit ?? null,
-      last_seen: last_seen ?? null,
-    })
+    last_seen?: OperationKey,
+  ): Promise<[OperationKey, OperationLog][]> {
+    return await this.client.rpcSingle<[OperationKey, OperationLog][]>(
+      '',
+      'list_operations',
+      {
+        limit: limit ?? null,
+        last_seen: last_seen ?? null,
+      },
+    )
   }
 
   async getOperation(operationId: string) {
-    return await this.client.rpcSingle<GetOperationResponse>(
+    return await this.client.rpcSingle<OperationLog | null>(
       '',
       'get_operation',
       { operation_id: operationId },
@@ -43,118 +52,165 @@ export class FederationService {
 
   async listTransactions(
     limit?: number,
-    last_seen?: lastSeenRequest,
+    last_seen?: OperationKey,
   ): Promise<Transactions[]> {
     const operations = await this.listOperations(limit, last_seen)
     return operations
       .filter(
-        (item): item is [any, any] => Array.isArray(item) && item.length === 2,
+        (item): item is [OperationKey, OperationLog] =>
+          Array.isArray(item) && item.length === 2,
       )
-      .filter(([_, op]: [any, any]) => {
-        const moduleKind = op.operation_module_kind
-        const variant = op.meta?.variant || {}
+      .filter(([_, op]) => {
+        const { operation_module_kind, meta } = op
+        const variant = meta.variant
         return (
-          (moduleKind === 'ln' && (variant.pay || variant.receive)) ||
-          (moduleKind === 'mint' &&
-            (variant.spend_o_o_b || variant.reissuance)) ||
-          (moduleKind === 'wallet' && (variant.deposit || variant.withdraw))
+          (operation_module_kind === 'ln' &&
+            ((variant as LnVariant).pay || (variant as LnVariant).receive)) ||
+          (operation_module_kind === 'mint' &&
+            ((variant as MintVariant).spend_o_o_b ||
+              (variant as MintVariant).reissuance)) ||
+          (operation_module_kind === 'wallet' &&
+            ((variant as WalletVariant).deposit ||
+              (variant as WalletVariant).withdraw))
         )
       })
       .map(([key, op]) => {
-        const timeStamp = key.creation_time
-          ? new Date(
+        const timestamp = key.creation_time
+          ? Math.round(
               key.creation_time.secs_since_epoch * 1000 +
                 key.creation_time.nanos_since_epoch / 1_000_000,
-            ).toLocaleString()
-          : '-'
+            )
+          : 0
         const operationId = key.operation_id
-        const moduleKind = op.operation_module_kind
-        let amount = 'N/A'
-        let paymentType = 'unknown'
-        let invoice = 'N/A'
-        const meta = op.meta || {}
-        const variant = meta.variant || {}
+        const kind = op.operation_module_kind as 'ln' | 'mint' | 'wallet'
+        const meta = op.meta
+        const variant = meta.variant
 
-        if (moduleKind === 'ln') {
-          paymentType = variant.pay
-            ? 'send'
-            : variant.receive
-              ? 'receive'
-              : 'unknown'
-        } else if (moduleKind === 'mint') {
-          paymentType = variant.spend_o_o_b
-            ? 'spend_oob'
-            : variant.reissuance
-              ? 'reissue'
-              : 'unknown'
-        }
-
-        let outcome: string
-        if (!op.outcome?.outcome) {
-          outcome = 'N/A'
-        } else if (typeof op.outcome.outcome === 'object') {
-          if ('success' in op.outcome.outcome) {
-            outcome = 'success'
-          } else if ('canceled' in op.outcome.outcome) {
-            outcome = 'canceled'
-          } else if ('WaitingForConfirmation' in op.outcome.outcome) {
-            outcome = 'pending'
-          } else if ('Confirmed' in op.outcome.outcome) {
-            outcome = 'confirmed'
-          } else if ('Claimed' in op.outcome.outcome) {
-            outcome = 'claimed'
-          } else {
-            outcome = 'unknown'
-          }
-        } else {
-          outcome = op.outcome.outcome
-        }
-
-        if (moduleKind === 'mint') {
-          if (meta.amount && typeof meta.amount === 'number') {
-            amount = meta.amount.toString()
+        let outcome: string | undefined
+        if (op.outcome && op.outcome.outcome) {
+          if (typeof op.outcome.outcome === 'string') {
+            outcome = op.outcome.outcome
           } else if (
-            variant.spend_o_o_b?.requested_amount &&
-            typeof variant.spend_o_o_b.requested_amount === 'number'
+            typeof op.outcome.outcome === 'object' &&
+            op.outcome.outcome !== null
           ) {
-            amount = variant.spend_o_o_b.requested_amount
+            if ('success' in op.outcome.outcome) outcome = 'success'
+            else if ('canceled' in op.outcome.outcome) outcome = 'canceled'
+            else if ('claimed' in op.outcome.outcome) outcome = 'claimed'
+            else if ('funded' in op.outcome.outcome) outcome = 'funded'
+            else if ('awaiting_funds' in op.outcome.outcome)
+              outcome = 'awaiting_funds'
+            else if ('unexpected_error' in op.outcome.outcome)
+              outcome = 'unexpected_error'
+            else if ('created' in op.outcome.outcome) outcome = 'created'
+            else if ('waiting_for_refund' in op.outcome.outcome)
+              outcome = 'canceled'
+            else if ('awaiting_change' in op.outcome.outcome)
+              outcome = 'pending'
+            else if ('refunded' in op.outcome.outcome) outcome = 'refunded'
+            else if ('waiting_for_payment' in op.outcome.outcome)
+              outcome = 'awaiting_funds'
+            else if ('Created' in op.outcome.outcome) outcome = 'Created'
+            else if ('Success' in op.outcome.outcome) outcome = 'Success'
+            else if ('Refunded' in op.outcome.outcome) outcome = 'Refunded'
+            else if ('UserCanceledProcessing' in op.outcome.outcome)
+              outcome = 'UserCanceledProcessing'
+            else if ('UserCanceledSuccess' in op.outcome.outcome)
+              outcome = 'UserCanceledSuccess'
+            else if ('UserCanceledFailure' in op.outcome.outcome)
+              outcome = 'UserCanceledFailure'
+            else if ('WaitingForTransaction' in op.outcome.outcome)
+              outcome = 'pending'
+            else if ('WaitingForConfirmation' in op.outcome.outcome)
+              outcome = 'pending'
+            else if ('Confirmed' in op.outcome.outcome) outcome = 'Confirmed'
+            else if ('Claimed' in op.outcome.outcome) outcome = 'Claimed'
+            else if ('Failed' in op.outcome.outcome) outcome = 'Failed'
           }
-        } else if (moduleKind === 'ln') {
-          invoice = variant.pay?.invoice || variant.receive?.invoice
-        } else if (moduleKind === 'wallet') {
-          if (
-            variant.withdraw?.amount &&
-            typeof variant.withdraw.amount === 'number'
-          ) {
-            amount = variant.withdraw.amount.toString()
-          } else if (op.outcome && typeof op.outcome.outcome === 'object') {
-            const outcome = op.outcome.outcome
-            if (
-              ('WaitingForConfirmation' in outcome &&
-                outcome.WaitingForConfirmation.btc_deposited) ||
-              ('Confirmed' in outcome && outcome.Confirmed.btc_deposited) ||
-              ('Claimed' in outcome && outcome.Claimed.btc_deposited)
-            ) {
-              amount =
-                outcome.WaitingForConfirmation?.btc_deposited ||
-                outcome.Confirmed?.btc_deposited ||
-                outcome.Claimed?.btc_deposited
-            }
-          }
-          paymentType = variant.deposit ? 'deposit' : 'withdraw'
         }
 
-        return {
-          timeStamp,
-          paymentType,
-          type: moduleKind,
-          amount,
-          invoice,
-          operationId,
-          outcome,
-          gateway:
-            variant.pay?.gateway_id || variant.receive?.gateway_id || 'N/A',
+        if (kind === 'ln') {
+          const isPay = !!(variant as LnVariant).pay
+          const txId =
+            (variant as LnVariant).pay?.out_point.txid ||
+            (variant as LnVariant).receive?.out_point.txid ||
+            ''
+          const type = (variant as LnVariant).pay ? 'send' : 'receive'
+          const invoice =
+            (variant as LnVariant).pay?.invoice ||
+            (variant as LnVariant).receive?.invoice ||
+            ''
+          const gateway =
+            (variant as LnVariant).pay?.gateway_id ||
+            (variant as LnVariant).receive?.gateway_id ||
+            ''
+          const fee = (variant as LnVariant).pay?.fee
+          const internalPay = (variant as LnVariant).pay?.is_internal_payment
+          const preimage =
+            isPay &&
+            op.outcome?.outcome &&
+            typeof op.outcome.outcome === 'object' &&
+            'success' in op.outcome.outcome
+              ? op.outcome.outcome.success.preimage
+              : undefined
+
+          return {
+            timestamp,
+            operationId,
+            kind,
+            txId,
+            type,
+            invoice,
+            internalPay,
+            fee,
+            gateway,
+            outcome: outcome as LightningTransaction['outcome'],
+          } as LightningTransaction
+        } else if (kind === 'mint') {
+          const txId = (variant as MintVariant).reissuance?.txid
+          const type = (variant as MintVariant).reissuance
+            ? 'reissue'
+            : 'spend_oob'
+          const amountMsats = meta.amount
+          const notes = (variant as MintVariant).spend_o_o_b?.oob_notes
+
+          return {
+            timestamp,
+            type,
+            txId,
+            outcome: outcome as EcashTransaction['outcome'],
+            operationId,
+            amountMsats,
+            notes,
+            kind,
+          } as EcashTransaction
+        } else if (kind === 'wallet') {
+          const type = (variant as WalletVariant).deposit
+            ? 'deposit'
+            : 'withdraw'
+          const address =
+            (variant as WalletVariant).deposit?.address ||
+            (variant as WalletVariant).withdraw?.address ||
+            ''
+          const feeRate = (variant as WalletVariant).withdraw?.fee.fee_rate
+            .sats_per_kvb
+          const amountMsats =
+            (variant as WalletVariant).withdraw?.amountMsats || 0
+
+          return {
+            timestamp,
+            type,
+            onchainAddress: address,
+            fee: feeRate || 0,
+            amountMsats,
+            outcome,
+            kind,
+            operationId,
+          } as WalletTransaction
         }
       })
+      .filter(
+        (transaction): transaction is Transactions => transaction !== undefined,
+      )
   }
 }

--- a/packages/core-web/src/types/wallet.ts
+++ b/packages/core-web/src/types/wallet.ts
@@ -65,6 +65,12 @@ type StreamError = {
   end: never
 }
 
+type GetOperationResponse = {
+  operation_module_kind: string
+  meta: JSONValue
+  outcome?: { time: number; outcome: JSONValue }
+} | null
+
 type StreamSuccess<T extends JSONValue> = {
   data: T
   error: never
@@ -113,6 +119,22 @@ type WalletSummary = {
   unconfirmed_change_utxos: TxOutputSummary[]
 }
 
+type lastSeenRequest = {
+  creation_time: { nanos_since_epoch: number; secs_since_epoch: number }
+  operation_id: string
+}
+
+type Transactions = {
+  timeStamp: string
+  paymentType: string
+  type: string
+  amount: string
+  invoice: string
+  operationId: string
+  outcome: string
+  gateway: string
+}
+
 /** Keys are powers of 2 */
 type NoteCountByDenomination = Record<number, number>
 
@@ -138,4 +160,7 @@ export {
   WalletSummary,
   TxOutputSummary,
   NoteCountByDenomination,
+  GetOperationResponse,
+  lastSeenRequest,
+  Transactions,
 }

--- a/packages/core-web/src/types/wallet.ts
+++ b/packages/core-web/src/types/wallet.ts
@@ -65,12 +65,6 @@ type StreamError = {
   end: never
 }
 
-type GetOperationResponse = {
-  operation_module_kind: string
-  meta: JSONValue
-  outcome?: { time: number; outcome: JSONValue }
-} | null
-
 type StreamSuccess<T extends JSONValue> = {
   data: T
   error: never
@@ -111,6 +105,23 @@ type TxOutputSummary = {
   amount: number
 }
 
+type BtcOutPoint = {
+  txid: string
+  vout: number
+}
+
+type WalletDepositState =
+  | 'WaitingForTransaction'
+  | {
+      WaitingForConfirmation: {
+        btc_deposited: number
+        btc_out_point: BtcOutPoint
+      }
+    }
+  | { Confirmed: { btc_deposited: number; btc_out_point: BtcOutPoint } }
+  | { Claimed: { btc_deposited: number; btc_out_point: BtcOutPoint } }
+  | { Failed: string }
+
 type WalletSummary = {
   spendable_utxos: TxOutputSummary[]
   unsigned_peg_out_txos: TxOutputSummary[]
@@ -119,21 +130,119 @@ type WalletSummary = {
   unconfirmed_change_utxos: TxOutputSummary[]
 }
 
-type lastSeenRequest = {
+type LnVariant = {
+  pay?: {
+    gateway_id: string
+    invoice: string
+    fee: number
+    is_internal_payment: boolean
+    out_point: {
+      out_idx: number
+      txid: string
+    }
+  }
+  receive?: {
+    gateway_id: string
+    invoice: string
+    out_point: {
+      out_idx: number
+      txid: string
+    }
+  }
+}
+
+type MintVariant = {
+  spend_o_o_b?: {
+    requested_amount: number
+    oob_notes: string
+  }
+  reissuance?: {
+    txid: string
+  }
+}
+
+type WalletVariant = {
+  deposit?: {
+    address: string
+    tweak_idx: number
+  }
+  withdraw?: {
+    address: string
+    amountMsats: number
+    fee: {
+      fee_rate: {
+        sats_per_kvb: number
+      }
+      total_weight: number
+    }
+  }
+}
+
+type OperationKey = {
   creation_time: { nanos_since_epoch: number; secs_since_epoch: number }
   operation_id: string
 }
-
-type Transactions = {
-  timeStamp: string
-  paymentType: string
-  type: string
-  amount: string
-  invoice: string
-  operationId: string
-  outcome: string
-  gateway: string
+type OperationMeta = {
+  amount: number
+  extra_meta: JSONObject
+  variant: LnVariant | MintVariant | WalletVariant
 }
+
+type OperationLog = {
+  meta: OperationMeta
+  operation_module_kind: string
+  outcome: {
+    outcome: LnPayState | LnReceiveState | SpendNotesState | WalletDepositState
+  }
+}
+
+type BaseTransactions = {
+  timestamp: number
+  operationId: string
+  kind: 'ln' | 'mint' | 'wallet'
+}
+
+type LightningTransaction = BaseTransactions & {
+  type: 'send' | 'receive'
+  invoice: string
+  outcome:
+    | 'created'
+    | 'canceled'
+    | 'claimed'
+    | 'pending'
+    | 'success'
+    | 'funded'
+    | 'awaiting_funds'
+    | 'unexpected_error'
+  gateway: string
+  fee?: number
+  internalPay?: boolean
+  preimage?: string
+  txId: string
+}
+
+type EcashTransaction = BaseTransactions & {
+  type: 'spend_oob' | 'reissue'
+  amountMsats: number
+  outcome?: SpendNotesState | ReissueExternalNotesState
+  notes?: string
+  txId?: string
+}
+
+type WalletTransaction = BaseTransactions & {
+  type: 'withdraw' | 'deposit'
+  onchainAddress: string
+  amountMsats: number
+  fee: number
+  outcome?:
+    | 'WaitingForTransaction'
+    | 'WaitingForConfirmation'
+    | 'Confirmed'
+    | 'Claimed'
+    | 'Failed'
+}
+
+type Transactions = LightningTransaction | EcashTransaction | WalletTransaction
 
 /** Keys are powers of 2 */
 type NoteCountByDenomination = Record<number, number>
@@ -160,7 +269,13 @@ export {
   WalletSummary,
   TxOutputSummary,
   NoteCountByDenomination,
-  GetOperationResponse,
-  lastSeenRequest,
+  OperationKey,
+  OperationLog,
+  LnVariant,
+  MintVariant,
+  WalletVariant,
+  LightningTransaction,
+  EcashTransaction,
+  WalletTransaction,
   Transactions,
 }


### PR DESCRIPTION
- Added getOperation method to get Transaction data with the operation id to search for the transaction with specific operationid.
- Added pagination in listOperations method to get transaction history and operations with the paginations.
- Added a listTransactions method to get list of transactions with pagination filtering the listOperations.

Wasm build on [commit#81841444f126d61debca1ca4763db4dcee8b99b2](https://github.com/fedimint/fedimint/commit/81841444f126d61debca1ca4763db4dcee8b99b2)