### PR TITLE
fix: changeset job to avoid rerunning tests

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -17,7 +17,7 @@ jobs:
 
   changesets:
     name: Publish Changesets
-    # needs: verify
+    needs: verify
     permissions:
       contents: write
       id-token: write
@@ -46,18 +46,13 @@ jobs:
 
             # Build packages
             pnpm build
-
-            # Run Tests
-            pnpm test
           EOF
 
       - name: PR or Publish to NPM
         uses: changesets/action@v1
         with:
           publish: |
-            nix develop --accept-flake-config --command bash << EOF
-              pnpm release
-            EOF
+            nix develop --accept-flake-config --command pnpm changeset publish
           createGithubReleases: ${{ github.ref == 'refs/heads/main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm simple-git-hooks",
     "postinstall": "patch-package",
     "preview": "pnpm --filter vite-core preview",
-    "release": "pnpm run build:wasm && pnpm run build && pnpm changeset publish",
     "reset": "pnpm clean && pnpm build && pnpm preview",
     "changeset": "changeset",
     "version": "changeset version",


### PR DESCRIPTION
Few updated to the changeset workflow

* Re-add verify dependency
* Remove redundant test step
* Remove redundant wasm build