### PR TITLE
chore: export pnpm and node bins from dev shells

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -24,9 +24,15 @@ runs:
         authToken: ${{ inputs.cachix_auth_token }}
       continue-on-error: true
 
-    - name: Set Env
+    - name: Expose fedimint ref, Node, PNPM from dev shell
       shell: bash
       run: |
-        nix develop --accept-flake-config --command bash << EOF
+        nix develop --accept-flake-config --command bash << 'EOF'
           echo "FEDIMINT_REF=${{ env.FEDIMINT_REF }}" >> $GITHUB_ENV
+
+          NODE_BIN_DIR=$(dirname "$(which node)")
+          PNPM_BIN_DIR=$(dirname "$(which pnpm)")
+
+          echo "$NODE_BIN_DIR"  >> $GITHUB_PATH
+          echo "$PNPM_BIN_DIR" >> $GITHUB_PATH
         EOF


### PR DESCRIPTION
* export pnpm and node binaries from nix shell, so we can use pnpm outside of the dev shell