### PR TITLE
Use available gateways instead of list_gateways

### DIFF
--- a/.changeset/shaky-books-cut.md
+++ b/.changeset/shaky-books-cut.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core': patch
+---
+
+Added select_available_gateay rpc and use it for payments instead of list_gateways

--- a/packages/core/src/services/LightningService.ts
+++ b/packages/core/src/services/LightningService.ts
@@ -2,6 +2,7 @@ import { TransportClient } from '../transport'
 import type {
   CreateBolt11Response,
   GatewayInfo,
+  GetAvailableGatewayParams,
   JSONObject,
   LightningGateway,
   LnInternalPayState,
@@ -83,7 +84,10 @@ export class LightningService {
     )
   }
 
-  async getAvailableGateway(gateway?: LightningGateway, invoice?: string) {
+  async getAvailableGateway({
+    gateway,
+    invoice,
+  }: GetAvailableGatewayParams | undefined = {}) {
     return await this.client.rpcSingle<LightningGateway | null>(
       'ln',
       'select_available_gateway',
@@ -91,12 +95,13 @@ export class LightningService {
         maybe_gateway: gateway ?? null,
         maybe_invoice: invoice ?? null,
       },
+      this.clientName,
     )
   }
 
   private async _getDefaultGatewayInfo(invoice?: string) {
     await this.updateGatewayCache()
-    const gateway = await this.getAvailableGateway(undefined, invoice)
+    const gateway = await this.getAvailableGateway({ invoice })
     return gateway?.info ?? null
   }
 

--- a/packages/core/src/services/LightningService.ts
+++ b/packages/core/src/services/LightningService.ts
@@ -88,7 +88,7 @@ export class LightningService {
     gateway,
     invoice,
   }: GetAvailableGatewayParams | undefined = {}) {
-    return await this.client.rpcSingle<LightningGateway | null>(
+    return await this.client.rpcSingle<GatewayInfo | null>(
       'ln',
       'select_available_gateway',
       {
@@ -102,7 +102,7 @@ export class LightningService {
   private async _getDefaultGatewayInfo(invoice?: string) {
     await this.updateGatewayCache()
     const gateway = await this.getAvailableGateway({ invoice })
-    return gateway?.info ?? null
+    return gateway ?? null
   }
 
   /** https://sdk.fedimint.org/core/FedimintWallet/LightningService/payInvoice#lightning-payinvoice-invoice-string */

--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -11,6 +11,7 @@ type GatewayInfo = {
   route_hints: RouteHint[]
   fees: FeeToAmount
 }
+
 type LightningGateway = {
   info: GatewayInfo
   vetted: boolean
@@ -32,6 +33,11 @@ type OutgoingLightningPayment = {
 }
 
 type PayType = { lightning: string } | { internal: string }
+
+type GetAvailableGatewayParams = {
+  gateway?: LightningGateway
+  invoice?: string
+}
 
 type LnPayState =
   | 'created'
@@ -291,4 +297,5 @@ export {
   WalletTransaction,
   Transactions,
   WalletDepositState,
+  GetAvailableGatewayParams,
 }

--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -10,6 +10,10 @@ type GatewayInfo = {
   federation_index: number
   route_hints: RouteHint[]
   fees: FeeToAmount
+  gateway_redeem_key: string
+  lightning_alias: string
+  mint_channel_id: number
+  supports_private_payments: boolean
 }
 
 type LightningGateway = {
@@ -35,7 +39,7 @@ type OutgoingLightningPayment = {
 type PayType = { lightning: string } | { internal: string }
 
 type GetAvailableGatewayParams = {
-  gateway?: LightningGateway
+  gateway?: GatewayInfo
   invoice?: string
 }
 

--- a/packages/integration-tests/src/services/LightningService.test.ts
+++ b/packages/integration-tests/src/services/LightningService.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'vitest'
 import { keyPair } from '../test/crypto'
 import { walletTest } from '../test/fixtures'
+import { LightningGateway } from '@fedimint/core'
 
 walletTest(
   'createInvoice should create a bolt11 invoice',
@@ -262,5 +263,21 @@ walletTest(
         )
       })
     }
+  },
+)
+
+walletTest(
+  'getAvailableGateway should return a gateway',
+  async ({ wallet }) => {
+    expect(wallet).toBeDefined()
+    expect(wallet.isOpen()).toBe(true)
+
+    const gateway = await wallet.lightning.getAvailableGateway()
+    expect(gateway).toBeDefined()
+    expect(gateway).toMatchObject({
+      info: expect.any(Object),
+      vetted: expect.any(Boolean),
+      ttl: expect.any(Object),
+    } satisfies LightningGateway)
   },
 )

--- a/packages/integration-tests/src/services/LightningService.test.ts
+++ b/packages/integration-tests/src/services/LightningService.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'vitest'
 import { keyPair } from '../test/crypto'
 import { walletTest } from '../test/fixtures'
-import { LightningGateway } from '@fedimint/core'
 
 walletTest(
   'createInvoice should create a bolt11 invoice',
@@ -272,12 +271,16 @@ walletTest(
     expect(wallet).toBeDefined()
     expect(wallet.isOpen()).toBe(true)
 
+    await wallet.lightning.updateGatewayCache()
     const gateway = await wallet.lightning.getAvailableGateway()
     expect(gateway).toBeDefined()
     expect(gateway).toMatchObject({
-      info: expect.any(Object),
-      vetted: expect.any(Boolean),
-      ttl: expect.any(Object),
-    } satisfies LightningGateway)
+      api: expect.any(String),
+      fees: expect.any(Object),
+      gateway_id: expect.any(String),
+      gateway_redeem_key: expect.any(String),
+      node_pub_key: expect.any(String),
+      route_hints: expect.any(Array),
+    })
   },
 )


### PR DESCRIPTION
To use available gateways instead of list_gateways in payments to get the first gateway in the priority of availability and fees. [fedimint/fedimint #7736](https://github.com/fedimint/fedimint/pull/7736)