### PR TITLE
fix: nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,9 @@
         nixpkgs = fedimint.inputs.nixpkgs;
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [fedimint.overlays.all];
+          overlays = [
+             (import "${fedimint}/nix/overlays/esplora-electrs.nix")
+          ];
         };
       in
       {


### PR DESCRIPTION
Fix the nix dev shell by only including the required esplora-electrs overlay