### PR TITLE
fix: CI ignoring failing pnpm tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -66,9 +66,12 @@ jobs:
         with:
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Setup Nix shell and run commands
+      - name: Run pnpm tests
         run: |
           nix develop --accept-flake-config --command bash << EOF
+
+            set -euo pipefail
+
             # Install dependencies
             pnpm install
 


### PR DESCRIPTION
Always use `set -euo pipefail` in your bash scripts.