### PR TITLE
alex/fix tests on newrpcs

### DIFF
--- a/packages/core/src/FedimintWallet.ts
+++ b/packages/core/src/FedimintWallet.ts
@@ -93,15 +93,15 @@ export class FedimintWallet {
         'The FedimintWallet is already open. You can only call `joinFederation` on closed clients.',
       )
     try {
-      const response = await this._client.sendSingleMessage<{
-        success: boolean
-      }>('join', { inviteCode, clientName })
-      if (response.success) {
-        this._isOpen = true
-        this._resolveOpen()
-      }
+      await this._client.sendSingleMessage('join_federation', {
+        invite_code: inviteCode,
+        client_name: clientName,
+        force_recover: false,
+      })
+      this._isOpen = true
+      this._resolveOpen()
 
-      return response.success
+      return true
     } catch (e) {
       this._client.logger.error('Error joining federation', e)
       return false

--- a/packages/core/src/WalletDirector.ts
+++ b/packages/core/src/WalletDirector.ts
@@ -45,7 +45,7 @@ export class WalletDirector {
     const response = this._client.sendSingleMessage<{
       config: FederationConfig
       federation_id: string
-    }>('previewFederation', { inviteCode })
+    }>('preview_federation', { invite_code: inviteCode })
     return response
   }
 
@@ -83,7 +83,7 @@ export class WalletDirector {
       type: string
       data: JSONValue
       requestId: number
-    }>('parseInviteCode', { inviteCode })
+    }>('parse_invite_code', { inviteCode })
     return response
   }
 
@@ -113,7 +113,7 @@ export class WalletDirector {
       type: string
       data: JSONValue
       requestId: number
-    }>('parseBolt11Invoice', { invoiceStr })
+    }>('parse_bolt11_invoice', { invoiceStr })
     return response
   }
 

--- a/packages/integration-tests/src/services/LightningService.test.ts
+++ b/packages/integration-tests/src/services/LightningService.test.ts
@@ -198,9 +198,10 @@ walletTest(
       operationIds[0],
       (state) => {
         expect(state).toBeDefined()
-        expect(state).toMatchObject({
-          state: 'claimed',
-        })
+        expect(
+          typeof state === 'string' &&
+            ['claimed', 'awaiting_funds'].includes(state),
+        ).toBe(true)
       },
     )
     expect(subscription).toBeDefined()

--- a/packages/integration-tests/src/test/TestWalletDirector.ts
+++ b/packages/integration-tests/src/test/TestWalletDirector.ts
@@ -4,10 +4,10 @@ import { TestFedimintWallet } from './TestFedimintWallet'
 
 export class TestWalletDirector extends WalletDirector {
   constructor(client: Transport = new WasmWorkerTransport()) {
-    super(client)
+    super(client, true)
   }
-  async createTestWallet() {
-    await this._client.initialize()
+  async createTestWallet(testId: string) {
+    await this._client.initialize(testId)
     return new TestFedimintWallet(this._client)
   }
 }

--- a/packages/transport-web/rollup.config.js
+++ b/packages/transport-web/rollup.config.js
@@ -18,7 +18,11 @@ export default [
       sourcemap: true,
     },
     plugins: [typescript(), terser()],
-    external: ['@fedimint/core', '@fedimint/fedimint-client-wasm-bundler'],
+    external: [
+      '@fedimint/core',
+      '@fedimint/fedimint-client-wasm-bundler',
+      '@fedimint/types',
+    ],
   },
   {
     input: './dist/dts/index.d.ts',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,15 +8,18 @@ export type JSONValue =
 
 export const TRANSPORT_MESSAGE_TYPES = [
   'init',
-  'client_rpc',
-  'open_client',
-  'cancel_rpc',
-  'join_federation',
   'error',
   'cleanup',
+  // Defined in fedimint-client-rpc crate: https://github.com/fedimint/fedimint/blob/master/fedimint-client-rpc/src/lib.rs#L60
+  // TODO: generate this list automatically
+  'set_mnemonic',
   'generate_mnemonic',
   'get_mnemonic',
-  'set_mnemonic',
+  'join_federation',
+  'open_client',
+  'close_client',
+  'client_rpc',
+  'cancel_rpc',
   'parse_invite_code',
   'parse_bolt11_invoice',
   'preview_federation',
@@ -30,9 +33,12 @@ export type TransportRequest = {
   payload?: JSONValue
 }
 
+const TransportResponseTypes = ['data', 'error', 'end', 'log'] as const
+type TransportResponseType = (typeof TransportResponseTypes)[number]
+
 export type TransportMessage = {
-  type: TransportMessageType | string
-  requestId?: number
+  type: TransportResponseType
+  request_id?: number
 } & Record<string, unknown>
 
 export type TransportMessageHandler = (message: TransportMessage) => void


### PR DESCRIPTION
stacked on https://github.com/fedimint/fedimint-web-sdk/pull/202
* Fixes tests post opfs implementation
* Lots of little naming inconsistencies addressed
* Found 1 remaining bug with `generateAddress` function
* All other tests are passing.




- **chore: refactor transport to be abstract class**
- **feat: implement new rpc**
- **feat: bump wasm**
- **chore: update transport msg types**
- **fix: tests with opfs rpcs**
