### PR TITLE
fix: pnpm swalloing non-zero error codes when called recursively

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build WASM
         uses: ./.github/actions/build-wasm
 
-      - name: Setup Nix shell and run commands
+      - name: Run pnpm tests
         shell: bash
         run: |
           set -euo pipefail

--- a/scripts/setup_test_shell.sh
+++ b/scripts/setup_test_shell.sh
@@ -1,3 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-exec devimint wasm-test-setup --exec "$@"
+set -euo pipefail
+
+# Event though it would be better, do not use `exec` for this,
+# as pnpm seems to be swallowing non-zero error codes if it
+# is run like this, but only when this whole script is called from
+# another pnpm instance.
+devimint wasm-test-setup --exec "$@"


### PR DESCRIPTION
Before the change:

```
> bash ./scripts/setup_test_shell.sh  pnpm run test:lib
```

returns non-zero exit code.

```
> pnpm test
```

swallows non-zero exit code. The first command is what the second command executes under the hood.

Why? I have no idea, and no time to dig deeper, but looks like some special behavior of pnpm somewhere, detecting when its parent is also pnpm (?).