### PR TITLE
chore: move size job to verify flow to avoid double build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,6 @@ name: Pull Request
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-
   workflow_dispatch:
 
 concurrency:
@@ -13,33 +12,3 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
-
-  size:
-    name: Size
-    runs-on: [self-hosted, linux, x64]
-    timeout-minutes: 10
-
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-
-      - name: Setup Nix
-        uses: ./.github/actions/setup-nix
-        with:
-          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - name: Build WASM
-        uses: ./.github/actions/build-wasm
-
-      - name: Report build size
-        # Fork modifies build-script to run arbitrary buildScript instead of pnpm run ${buildScript}
-        uses: alexlwn123/compressed-size-action@alex/fix-build
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pattern: '{packages/**/dist/**/*.{js,mjs,cjs},packages/**/*.wasm}'
-          install-script: pnpm install
-          build-script: pnpm build
-
-      # https://github.com/actions/checkout/issues/692#issuecomment-1502203573
-      - name: Cleanup checkout
-        uses: actions/checkout@v4

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -86,6 +86,14 @@ jobs:
           # Run Tests
           nix develop --accept-flake-config --command pnpm test
 
+      - name: Report Size
+        uses: alexlwn123/compressed-size-action@alex/fix-build
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: '{packages/**/dist/**/*.{js,mjs,cjs},packages/**/*.wasm}'
+          install-script: pnpm install
+          build-script: pnpm build
+
   build-docs:
     name: Build Docs
     runs-on: ubuntu-latest


### PR DESCRIPTION
Avoids double builds to speed up CI.