### PR TITLE
fix: update fedimint and fedimint-wasm to v0.10.0 in flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1753275806,
-        "narHash": "sha256-E+Cu/AFVGwoQo4KPgcWmFS9zU7fJgXoK0o25EP3j48g=",
+        "lastModified": 1766435619,
+        "narHash": "sha256-3A5Z5K28YB45REOHMWtyQ24cEUXW76MOtbT6abPrARE=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "c62e71ad8c5256ffa3cafbb1a8c687db60869e98",
+        "rev": "a98dbc80b16730a64c612c6ab5d5fecb4ebb79ba",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "advisory-db_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1753275806,
-        "narHash": "sha256-E+Cu/AFVGwoQo4KPgcWmFS9zU7fJgXoK0o25EP3j48g=",
+        "lastModified": 1766435619,
+        "narHash": "sha256-3A5Z5K28YB45REOHMWtyQ24cEUXW76MOtbT6abPrARE=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "c62e71ad8c5256ffa3cafbb1a8c687db60869e98",
+        "rev": "a98dbc80b16730a64c612c6ab5d5fecb4ebb79ba",
         "type": "github"
       },
       "original": {
@@ -69,16 +69,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1749500520,
+        "lastModified": 1762287806,
+        "narHash": "sha256-tmF7Fm2VNukLV32w60QiFLDJB4cO26lhKdDLR8k1BX0=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "7dc07be20c7a516cc7490969c4072ff692fb1b27",
+        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
         "type": "github"
       },
       "original": {
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "7dc07be20c7a516cc7490969c4072ff692fb1b27",
+        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
         "type": "github"
       }
     },
@@ -249,20 +250,51 @@
     },
     "crane_2": {
       "locked": {
-        "lastModified": 1745454774,
+        "lastModified": 1758758545,
+        "narHash": "sha256-NU5WaEdfwF6i8faJ2Yh+jcK9vVFrofLcwlD/mP65JrI=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
+        "rev": "95d528a5f54eaba0d12102249ce42f4d01f4e364",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.21.1",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_3": {
+      "locked": {
+        "lastModified": 1755993354,
+        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
         "type": "github"
       }
     },
-    "crane_3": {
+    "crane_4": {
+      "locked": {
+        "lastModified": 1755993354,
+        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_5": {
       "inputs": {
         "nixpkgs": [
           "fedimint-wasm",
@@ -286,7 +318,7 @@
         "type": "github"
       }
     },
-    "crane_4": {
+    "crane_6": {
       "locked": {
         "lastModified": 1758758545,
         "narHash": "sha256-NU5WaEdfwF6i8faJ2Yh+jcK9vVFrofLcwlD/mP65JrI=",
@@ -302,7 +334,7 @@
         "type": "github"
       }
     },
-    "crane_5": {
+    "crane_7": {
       "locked": {
         "lastModified": 1755993354,
         "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
@@ -317,7 +349,7 @@
         "type": "github"
       }
     },
-    "crane_6": {
+    "crane_8": {
       "locked": {
         "lastModified": 1755993354,
         "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
@@ -437,19 +469,20 @@
         "flake-utils": "flake-utils_5",
         "flakebox": "flakebox_2",
         "nixpkgs": "nixpkgs_4",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "wild": "wild_2"
       },
       "locked": {
-        "lastModified": 1765206617,
-        "narHash": "sha256-dqLZyLpwByW6HwCl6gEelf175D6BYDYbE/Sf9Y4IGmg=",
+        "lastModified": 1768965582,
+        "narHash": "sha256-x2AC5SLXVqwV/1wNhDzfjfAPFH3ByOyGh5ogbOjSJ2k=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "c3084c446cd24dc120ce7201c984acc079fc4add",
+        "rev": "76f6c7ce5435a609a256d58b0924161c5fc9b3ec",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
-        "ref": "v0.9.1",
+        "ref": "v0.10.0",
         "repo": "fedimint",
         "type": "github"
       }
@@ -464,20 +497,20 @@
         "flakebox": "flakebox_4",
         "nixpkgs": "nixpkgs_8",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
-        "wild": "wild_2"
+        "wild": "wild_4"
       },
       "locked": {
-        "lastModified": 1763746100,
-        "narHash": "sha256-a+V5L6bBJT2Gbh+QtB1db9YbiGlr4JKlpsn49ZshNV4=",
+        "lastModified": 1768965582,
+        "narHash": "sha256-x2AC5SLXVqwV/1wNhDzfjfAPFH3ByOyGh5ogbOjSJ2k=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "c2350bb7528fff6100968d23ddeb626653c5ebb0",
+        "rev": "76f6c7ce5435a609a256d58b0924161c5fc9b3ec",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
+        "ref": "v0.10.0",
         "repo": "fedimint",
-        "rev": "c2350bb7528fff6100968d23ddeb626653c5ebb0",
         "type": "github"
       }
     },
@@ -582,11 +615,11 @@
         "rust-analyzer-src": "rust-analyzer-src_5"
       },
       "locked": {
-        "lastModified": 1769966877,
-        "narHash": "sha256-saM3CldynDtMFHRc25UdQ7EQtP5o+oSUgsHTMvIzzXw=",
+        "lastModified": 1775891769,
+        "narHash": "sha256-EOfVlTKw2n8w1uhfh46GS4hEGnQ7oWrIWQfIY6utIkI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8a42e00e442d416e6c838fc6b40240da65aacbcd",
+        "rev": "6fbc54dde15aee725bdc7aae5e478849685d5f56",
         "type": "github"
       },
       "original": {
@@ -832,6 +865,7 @@
       },
       "locked": {
         "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
@@ -912,27 +946,28 @@
           "fedimint",
           "nixpkgs"
         ],
-        "systems": "systems_8"
+        "systems": "systems_8",
+        "wild": "wild"
       },
       "locked": {
-        "lastModified": 1755720430,
-        "narHash": "sha256-oDgZKL9U5RExRgmoTAmy+H+wZaN2/mHBPitT5Hnv1ic=",
+        "lastModified": 1768010000,
+        "narHash": "sha256-/oUVHAj020wdMzgmBtojT58hwHkS9/CoHp/2x1k6dEE=",
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "2f15f65d60c198fe49d849d68c2a2c95dc771ae5",
+        "rev": "3e20ed1239ea83da3790ae2f2d207b508b429c2b",
         "type": "github"
       },
       "original": {
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "2f15f65d60c198fe49d849d68c2a2c95dc771ae5",
+        "rev": "3e20ed1239ea83da3790ae2f2d207b508b429c2b",
         "type": "github"
       }
     },
     "flakebox_3": {
       "inputs": {
         "android-nixpkgs": "android-nixpkgs_3",
-        "crane": "crane_3",
+        "crane": "crane_5",
         "fenix": "fenix_3",
         "flake-utils": "flake-utils_11",
         "nixpkgs": "nixpkgs_7",
@@ -955,7 +990,7 @@
     "flakebox_4": {
       "inputs": {
         "android-nixpkgs": "android-nixpkgs_4",
-        "crane": "crane_4",
+        "crane": "crane_6",
         "fenix": [
           "fedimint-wasm",
           "fenix"
@@ -966,20 +1001,20 @@
           "nixpkgs"
         ],
         "systems": "systems_16",
-        "wild": "wild"
+        "wild": "wild_3"
       },
       "locked": {
-        "lastModified": 1762577276,
-        "narHash": "sha256-4hDlMtyHITW9boM6zdJIaDp/mvSiUwO/BdCCLQjxEw4=",
+        "lastModified": 1768010000,
+        "narHash": "sha256-/oUVHAj020wdMzgmBtojT58hwHkS9/CoHp/2x1k6dEE=",
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "9a22c690bc3c15291c3c70f662c855b5bdaffc0e",
+        "rev": "3e20ed1239ea83da3790ae2f2d207b508b429c2b",
         "type": "github"
       },
       "original": {
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "9a22c690bc3c15291c3c70f662c855b5bdaffc0e",
+        "rev": "3e20ed1239ea83da3790ae2f2d207b508b429c2b",
         "type": "github"
       }
     },
@@ -1084,33 +1119,33 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1753694789,
-        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
+        "lastModified": 1762605048,
+        "narHash": "sha256-prkwN3TKiG1T7Qi4PwAknD6h8iLapgqt4nfyUdsVFKg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
+        "rev": "d157ecd9b559c9103c4d69904277c37e062344bf",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "d157ecd9b559c9103c4d69904277c37e062344bf",
         "type": "github"
       }
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1753694789,
-        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
+        "lastModified": 1762605048,
+        "narHash": "sha256-prkwN3TKiG1T7Qi4PwAknD6h8iLapgqt4nfyUdsVFKg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
+        "rev": "d157ecd9b559c9103c4d69904277c37e062344bf",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "d157ecd9b559c9103c4d69904277c37e062344bf",
         "type": "github"
       }
     },
@@ -1148,16 +1183,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1758589230,
-        "narHash": "sha256-zMTCFGe8aVGTEr2RqUi/QzC1nOIQ0N1HRsbqB4f646k=",
+        "lastModified": 1766473571,
+        "narHash": "sha256-5G1NDO2PulBx1RoaA6U1YoUDX0qZslpPxv+n5GX6Qto=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d1d883129b193f0b495d75c148c2c3a7d95789a0",
+        "rev": "76701a179d3a98b07653e2b0409847499b2a07d3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1211,16 +1246,16 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1762111121,
-        "narHash": "sha256-4vhDuZ7OZaZmKKrnDpxLZZpGIJvAeMtK6FKLJYUtAdw=",
+        "lastModified": 1766473571,
+        "narHash": "sha256-5G1NDO2PulBx1RoaA6U1YoUDX0qZslpPxv+n5GX6Qto=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+        "rev": "76701a179d3a98b07653e2b0409847499b2a07d3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1304,11 +1339,11 @@
     "rust-analyzer-src_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1769857242,
-        "narHash": "sha256-3eKpRRzKz0KzY7CJzRXFm4POwEqbuTohyQ2ajI/zKvg=",
+        "lastModified": 1775843361,
+        "narHash": "sha256-j53ZgyDvmYf3Sjh1IPvvTjqa614qUfVQSzj59+MpzkY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "17304e9c7e11d26139672d3d77aa498b1cae0d69",
+        "rev": "9eb97ea96d8400e8957ddd56702e962614296583",
         "type": "github"
       },
       "original": {
@@ -1546,6 +1581,7 @@
     "systems_8": {
       "locked": {
         "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
         "repo": "default",
         "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
@@ -1610,9 +1646,9 @@
     },
     "wild": {
       "inputs": {
-        "crane": "crane_5",
+        "crane": "crane_3",
         "nixpkgs": [
-          "fedimint-wasm",
+          "fedimint",
           "flakebox",
           "nixpkgs"
         ]
@@ -1634,7 +1670,53 @@
     },
     "wild_2": {
       "inputs": {
-        "crane": "crane_6",
+        "crane": "crane_4",
+        "nixpkgs": [
+          "fedimint",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762215977,
+        "narHash": "sha256-x0IZuWjj0LRMj4pu2FVaD8SENm/UVtE1e4rl0EOZZZM=",
+        "owner": "davidlattimore",
+        "repo": "wild",
+        "rev": "7daaf0c89f7b4b9c9ded36e7b3c72aa6512537a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davidlattimore",
+        "repo": "wild",
+        "type": "github"
+      }
+    },
+    "wild_3": {
+      "inputs": {
+        "crane": "crane_7",
+        "nixpkgs": [
+          "fedimint-wasm",
+          "flakebox",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762215977,
+        "narHash": "sha256-x0IZuWjj0LRMj4pu2FVaD8SENm/UVtE1e4rl0EOZZZM=",
+        "owner": "davidlattimore",
+        "repo": "wild",
+        "rev": "7daaf0c89f7b4b9c9ded36e7b3c72aa6512537a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davidlattimore",
+        "ref": "0.7.0",
+        "repo": "wild",
+        "type": "github"
+      }
+    },
+    "wild_4": {
+      "inputs": {
+        "crane": "crane_8",
         "nixpkgs": [
           "fedimint-wasm",
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,10 @@
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
       # Devimint input - Should point to a release tag, as it doesn't need to be updated often.
-      url = "github:fedimint/fedimint/v0.9.1";
+      url = "github:fedimint/fedimint/v0.10.0";
     };
     fedimint-wasm = {
-         url = "github:fedimint/fedimint?rev=c2350bb7528fff6100968d23ddeb626653c5ebb0";
+         url = "github:fedimint/fedimint/v0.10.0";
     };
     fenix = {
       url = "github:nix-community/fenix";

--- a/flake.nix
+++ b/flake.nix
@@ -289,6 +289,7 @@
                fedimint.packages.${system}.gateway-pkgs
                fedimint.packages.${system}.fedimint-pkgs
                fedimint.packages.${system}.fedimint-recurringd
+               fedimint.packages.${system}.fedimint-recurringdv2
              ] ++ [ wasmToolchain ];
              shellHook = wasmShellHook;
           };

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "glob": "^10.4.5",
     "happy-dom": "^20.7.0",
     "patch-package": "^8.0.1",
-    "playwright": "1.52.0",
+    "playwright": "1.56.1",
     "prettier": "^3.8.1",
     "sherif": "^0.8.4",
     "simple-git-hooks": "^2.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 22.19.11
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(playwright@1.52.0)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vitest@3.2.4)
+        version: 3.2.4(playwright@1.56.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
@@ -42,8 +42,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1
       playwright:
-        specifier: 1.52.0
-        version: 1.52.0
+        specifier: 1.56.1
+        version: 1.56.1
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -8092,13 +8092,13 @@ packages:
     resolution: {integrity: sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.52.0:
-    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.52.0:
-    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
+  playwright@1.56.1:
+    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -14359,7 +14359,7 @@ snapshots:
       vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0)
       vue: 3.5.27(typescript@5.9.3)
 
-  '@vitest/browser@3.2.4(playwright@1.52.0)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(playwright@1.56.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
@@ -14371,7 +14371,7 @@ snapshots:
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@20.0.3)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       ws: 8.19.0
     optionalDependencies:
-      playwright: 1.52.0
+      playwright: 1.56.1
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14395,7 +14395,7 @@ snapshots:
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@20.0.3)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(playwright@1.52.0)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -19462,11 +19462,11 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  playwright-core@1.52.0: {}
+  playwright-core@1.56.1: {}
 
-  playwright@1.52.0:
+  playwright@1.56.1:
     dependencies:
-      playwright-core: 1.52.0
+      playwright-core: 1.56.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -21475,7 +21475,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.19.11
-      '@vitest/browser': 3.2.4(playwright@1.52.0)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vitest@3.2.4)
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 20.7.0
       jsdom: 20.0.3


### PR DESCRIPTION
fixes #270 

to verify run:

```bash
pnpm build:wasm
strings packages/wasm-bundler/fedimint_client_wasm_bg.wasm | rg 'has_mnemonic_set'
```
expected output:
```bash
request_idset_mnemonicgenerate_mnemonicget_mnemonichas_mnemonic_setjoin_federationopen_clientclose_clientclient_rpccancel_rpcparse_invite_codeparse_bolt11_invoicepreview_federationparse_oob_notes
```