### PR TITLE
feat: expose client event log

### DIFF
--- a/.changeset/gentle-rings-appear.md
+++ b/.changeset/gentle-rings-appear.md
@@ -1,5 +1,7 @@
 ---
 '@fedimint/core': patch
+'@fedimint/fedimint-client-wasm-bundler': patch
+'@fedimint/fedimint-client-wasm-web': patch
 ---
 
 Add `federation.getEventLog()` for reading paginated persistent client event log entries

--- a/.changeset/gentle-rings-appear.md
+++ b/.changeset/gentle-rings-appear.md
@@ -1,5 +1,5 @@
 ---
-'@fedimint/core': minor
+'@fedimint/core': patch
 ---
 
 Add `federation.getEventLog()` for reading paginated persistent client event log entries

--- a/.changeset/gentle-rings-appear.md
+++ b/.changeset/gentle-rings-appear.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core': minor
+---
+
+Add `federation.getEventLog()` for reading paginated persistent client event log entries

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -152,6 +152,7 @@ const FedimintWalletSidebar = [
           { text: 'getFederationId()', link: 'getFederationId' },
           { text: 'getInviteCode()', link: 'getInviteCode' },
           { text: 'getOperation()', link: 'getOperation' },
+          { text: 'getEventLog()', link: 'getEventLog' },
           { text: 'listOperations()', link: 'listOperations' },
           { text: 'listTransactions()', link: 'listTransactions' },
           { text: 'getMetaConsensusValue()', link: 'getMetaConsensusValue' },

--- a/docs/core/FedimintWallet/FederationService/getEventLog.md
+++ b/docs/core/FedimintWallet/FederationService/getEventLog.md
@@ -1,0 +1,39 @@
+# Get Event Log
+
+### `federation.getEventLog(params?: EventLogParams)`
+
+Returns persisted client event log entries for the connected federation. Pass
+`pos` to start reading from a specific event id and `limit` to cap the number
+of returned entries. If no `limit` is given, `10_000` is used as the limit.
+
+```ts twoslash
+type EventLogParams = {
+  pos?: number | null
+  limit?: number | null
+}
+
+type PersistedLogEntry = {
+  id: number
+  kind: string
+  module: [string, number] | null
+  ts_usecs: number
+  payload: unknown
+}
+```
+
+```ts twoslash
+// @esModuleInterop
+import { WalletDirector } from '@fedimint/core'
+import { WasmWorkerTransport } from '@fedimint/transport-web'
+
+const director = new WalletDirector(new WasmWorkerTransport())
+const wallet = await director.createWallet()
+
+await wallet.open()
+
+const eventLog = await wallet.federation.getEventLog({
+  pos: 0,
+  limit: 20,
+})
+console.log('event log entries are: ', eventLog)
+```

--- a/flake.lock
+++ b/flake.lock
@@ -638,17 +638,17 @@
         "wild": "wild_4"
       },
       "locked": {
-        "lastModified": 1776688274,
-        "narHash": "sha256-1rCyVaMLdnoxL5NRp5Ko3/iUkM4Ctno0E88DCRWAW1E=",
+        "lastModified": 1779209232,
+        "narHash": "sha256-X8tW55Sc306zYM6L+ISPpLienb0kGLnyv/Y0E90DzIY=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "4b0d77d9fc660082ea3b24d33e3900ef9400b20a",
+        "rev": "382afc209c80e5445c65ccfabd37edf282669291",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "4b0d77d9fc660082ea3b24d33e3900ef9400b20a",
+        "rev": "382afc209c80e5445c65ccfabd37edf282669291",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,8 @@
       url = "github:fedimint/fedimint/v0.10.0";
     };
     fedimint-wasm = {
-         url = "github:fedimint/fedimint?rev=4b0d77d9fc660082ea3b24d33e3900ef9400b20a";
+         url = "github:fedimint/fedimint?rev=382afc209c80e5445c65ccfabd37edf282669291";
+         
     };
     fedimint-sdk-ffi = {
       # Provides cross-compiled Android (.so) and iOS (.a) bindings as

--- a/packages/core/src/services/FederationService.ts
+++ b/packages/core/src/services/FederationService.ts
@@ -1,5 +1,6 @@
 import type {
   EcashTransaction,
+  EventLogParams,
   JSONValue,
   LightningTransaction,
   LnVariant,
@@ -7,6 +8,7 @@ import type {
   MintVariant,
   OperationKey,
   OperationLog,
+  PersistedLogEntry,
   Transactions,
   WalletTransaction,
   WalletVariant,
@@ -79,6 +81,18 @@ export class FederationService {
       '',
       'get_operation',
       { operation_id: operationId },
+      this.clientName,
+    )
+  }
+
+  async getEventLog(params: EventLogParams = {}): Promise<PersistedLogEntry[]> {
+    return await this.client.rpcSingle<PersistedLogEntry[]>(
+      '',
+      'get_event_log',
+      {
+        pos: params.pos ?? null,
+        limit: params.limit ?? null,
+      },
       this.clientName,
     )
   }

--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -217,6 +217,19 @@ type OperationLog = {
   }
 }
 
+type EventLogParams = {
+  pos?: number | null
+  limit?: number | null
+}
+
+type PersistedLogEntry = {
+  id: number
+  kind: string
+  module: [string, number] | null
+  ts_usecs: number
+  payload: JSONValue
+}
+
 type BaseTransactions = {
   timestamp: number
   operationId: string
@@ -299,6 +312,8 @@ export {
   GenerateAddressResponse,
   OperationKey,
   OperationLog,
+  EventLogParams,
+  PersistedLogEntry,
   LnVariant,
   MintVariant,
   WalletVariant,


### PR DESCRIPTION
fixes #287

* Bumps the Fedimint WASM input to a newer fedimint revision.
* Updates the locked fedimint-wasm flake input so builds resolve the intended commit.
* Exposes the new client event log API through the web SDK federation service/types.
