### PR TITLE
feat: add forceRecover option to joinFederation

### DIFF
--- a/.changeset/join-federation-force-recover.md
+++ b/.changeset/join-federation-force-recover.md
@@ -1,5 +1,5 @@
 ---
-'@fedimint/core': minor
+'@fedimint/core': patch
 ---
 
 Added `forceRecover` support to `FedimintWallet.joinFederation()` through a backwards-compatible options object.

--- a/.changeset/join-federation-force-recover.md
+++ b/.changeset/join-federation-force-recover.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core': minor
+---
+
+Added `forceRecover` support to `FedimintWallet.joinFederation()` through a backwards-compatible options object.

--- a/docs/core/FedimintWallet/joinFederation.md
+++ b/docs/core/FedimintWallet/joinFederation.md
@@ -1,6 +1,6 @@
 # joinFederation
 
-### `joinFederation(federationId: string)`
+### `joinFederation(inviteCode: string, clientNameOrOptions?: string | JoinFederationOptions)`
 
 Attempts to join a federation.
 
@@ -19,7 +19,7 @@ if (didJoin) {
 }
 ```
 
-To support multiple wallets within a single application, you can pass in a custom client name.
+To support multiple wallets within a single application, pass a custom client name.
 
 ```ts twoslash
 // @esModuleInterop
@@ -30,4 +30,34 @@ const director = new WalletDirector(new WasmWorkerTransport())
 const wallet = await director.createWallet()
 
 const didJoin = await wallet.joinFederation('fed456...', 'my-client-name') // [!code focus]
+```
+
+You can also pass an options object. This is the preferred form when setting `forceRecover`.
+
+```ts twoslash
+// @esModuleInterop
+import { WalletDirector } from '@fedimint/core'
+import { WasmWorkerTransport } from '@fedimint/transport-web'
+
+const director = new WalletDirector(new WasmWorkerTransport())
+const wallet = await director.createWallet()
+
+const didJoin = await wallet.joinFederation('fed456...', {
+  clientName: 'my-client-name',
+}) // [!code focus]
+```
+
+To force recovery while joining, set `forceRecover`.
+
+```ts twoslash
+// @esModuleInterop
+import { WalletDirector } from '@fedimint/core'
+import { WasmWorkerTransport } from '@fedimint/transport-web'
+
+const director = new WalletDirector(new WasmWorkerTransport())
+const wallet = await director.createWallet()
+
+const didJoin = await wallet.joinFederation('fed789...', {
+  forceRecover: true,
+}) // [!code focus]
 ```

--- a/packages/core/src/FedimintWallet.ts
+++ b/packages/core/src/FedimintWallet.ts
@@ -12,6 +12,11 @@ import {
 // This is temporary until we have a proper client management system
 const DEFAULT_CLIENT_NAME = 'dd5135b2-c228-41b7-a4f9-3b6e7afe3088' as const
 
+export type JoinFederationOptions = {
+  clientName?: string
+  forceRecover?: boolean
+}
+
 export class FedimintWallet {
   public balance: BalanceService
   public mint: MintService
@@ -88,8 +93,27 @@ export class FedimintWallet {
 
   async joinFederation(
     inviteCode: string,
-    clientName: string = DEFAULT_CLIENT_NAME,
-  ) {
+    clientName?: string,
+  ): Promise<boolean>
+  async joinFederation(
+    inviteCode: string,
+    options?: JoinFederationOptions,
+  ): Promise<boolean>
+  async joinFederation(
+    inviteCode: string,
+    clientNameOrOptions: string | JoinFederationOptions = DEFAULT_CLIENT_NAME,
+  ): Promise<boolean> {
+    const options =
+      typeof clientNameOrOptions === 'string'
+        ? {
+            clientName: clientNameOrOptions,
+            forceRecover: false,
+          }
+        : {
+            clientName: clientNameOrOptions.clientName ?? DEFAULT_CLIENT_NAME,
+            forceRecover: clientNameOrOptions.forceRecover ?? false,
+          }
+
     // TODO: Determine if this should be safe or throw
     if (this._isOpen)
       throw new Error(
@@ -98,8 +122,8 @@ export class FedimintWallet {
     try {
       await this._client.sendSingleMessage('join_federation', {
         invite_code: inviteCode,
-        client_name: clientName,
-        force_recover: false,
+        client_name: options.clientName,
+        force_recover: options.forceRecover,
       })
       this._isOpen = true
       this._resolveOpen()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 export { WalletDirector } from './WalletDirector'
 export { TransportClient } from './transport'
 export { DEFAULT_META_KEY } from './services/FederationService'
-export type { FedimintWallet } from './FedimintWallet'
+export type { FedimintWallet, JoinFederationOptions } from './FedimintWallet'
 export type * from './types'
 export type {
   ParsedInviteCode,

--- a/packages/integration-tests/src/FedimintWallet.test.ts
+++ b/packages/integration-tests/src/FedimintWallet.test.ts
@@ -1,4 +1,6 @@
-import { expect } from 'vitest'
+import { TransportClient } from '@fedimint/core'
+import { FedimintWallet } from '@fedimint/core/testing'
+import { expect, vi } from 'vitest'
 import { walletTest } from './test/fixtures'
 
 walletTest('get invite code from devimint', async ({ wallet }) => {
@@ -11,6 +13,49 @@ walletTest('fund wallet with devimint', async ({ fundedWallet }) => {
   expect(fundedWallet).toBeDefined()
   const balance = await fundedWallet.balance.getBalance()
   expect(balance).toBeGreaterThan(0)
+})
+
+walletTest('joinFederation passes options to the transport', async () => {
+  const sendSingleMessage = vi.fn().mockResolvedValue(undefined)
+  const wallet = new FedimintWallet({
+    sendSingleMessage,
+    logger: {
+      error: vi.fn(),
+    },
+  } as unknown as TransportClient)
+
+  await expect(
+    wallet.joinFederation('fed123...', {
+      clientName: 'my-client-name',
+      forceRecover: true,
+    }),
+  ).resolves.toBe(true)
+
+  expect(sendSingleMessage).toHaveBeenCalledWith('join_federation', {
+    invite_code: 'fed123...',
+    client_name: 'my-client-name',
+    force_recover: true,
+  })
+})
+
+walletTest('joinFederation still accepts a client name string', async () => {
+  const sendSingleMessage = vi.fn().mockResolvedValue(undefined)
+  const wallet = new FedimintWallet({
+    sendSingleMessage,
+    logger: {
+      error: vi.fn(),
+    },
+  } as unknown as TransportClient)
+
+  await expect(
+    wallet.joinFederation('fed123...', 'my-client-name'),
+  ).resolves.toBe(true)
+
+  expect(sendSingleMessage).toHaveBeenCalledWith('join_federation', {
+    invite_code: 'fed123...',
+    client_name: 'my-client-name',
+    force_recover: false,
+  })
 })
 
 walletTest(


### PR DESCRIPTION
Adds a `forceRecover` option to `joinFederation`, while keeping the existing `joinFederation(inviteCode, clientName)` call working.

This is needed when restoring a wallet: after joining the federation again, `forceRecover` lets the client trigger recovery so the wallet balance can be restored.