### PR TITLE
chore: update packageManager to pnpm@11.12.0

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         cache: 'pnpm'
 
     - name: Install dependencies

--- a/examples/bare-js/package.json
+++ b/examples/bare-js/package.json
@@ -14,5 +14,5 @@
   "devDependencies": {
     "http-server": "^14.1.1"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@11.12.0"
 }

--- a/examples/vite-core/package.json
+++ b/examples/vite-core/package.json
@@ -24,5 +24,5 @@
     "vite": "^6.4.1",
     "vite-plugin-wasm": "^3.5.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@11.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -65,12 +65,7 @@
     "vite-plugin-wasm": "^3.5.0",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@9.15.9",
-  "pnpm": {
-    "overrides": {
-      "dom-serializer@2.0.0>entities": "4.4.0"
-    }
-  },
+  "packageManager": "pnpm@11.12.0",
   "engines": {
     "node": "22.x"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,13 @@ packages:
   - 'packages/*'
   - 'examples/*'
   - 'docs'
+
+allowBuilds:
+  esbuild: true
+  secp256k1: true
+  sharp: true
+  simple-git-hooks: true
+  vue-demi: true
+
+overrides:
+  'dom-serializer@2.0.0>entities': '4.4.0'


### PR DESCRIPTION
Migrates the workspace from `pnpm` v9 to `pnpm` v11.

*   Updated `packageManager` to `pnpm@11.12.0` across the project.
*   Moved `overrides` and configured `allowBuilds` in `pnpm-workspace.yaml` to comply with pnpm v11 workspace rules.
*   Upgraded Node.js to version `22` in the CI install-deps action (pnpm v11 requires Node.js >=22.13 for `node:sqlite`).

**Validation:** Clean install, lint, typecheck, and build all pass successfully.

Fix: #292
