### PR TITLE
ci: trigger react native builds on 'core/types' package changes

### DIFF
--- a/.github/workflows/react-native-pr.yml
+++ b/.github/workflows/react-native-pr.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'packages/react-native/**'
       - 'packages/react-native-bindings/**'
+      - 'packages/core/**'
+      - 'packages/types/**'
       - 'fedimint-sdk-ffi'
       - 'flake.nix'
       - 'flake.lock'

--- a/flake.lock
+++ b/flake.lock
@@ -612,11 +612,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1777591115,
-        "narHash": "sha256-DhX5mKp0rXNa/NJmrvRJvE0ASXV//BrzPtZktRetPiQ=",
+        "lastModified": 1784407339,
+        "narHash": "sha256-MTO67rA5ljg+G4IVFZqZFO666IuVkUa/Yp0FifTqXkI=",
         "owner": "fedimint",
         "repo": "fedimint-sdk-ffi",
-        "rev": "3da88e1d8244152d4ca03c6f5b7b53fccb124416",
+        "rev": "6873aa36ecca44a748a85d0cbc8bd2e2ba179732",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -201,6 +201,13 @@
                 export CXX_aarch64_apple_darwin=clang++
                 export CXX_x86_64_apple_darwin=clang++
 
+                # Bypass Nix's cc-wrapper for host builds — it hardcodes
+                # --sysroot to an incompatible apple-sdk-11 store path that
+                # lacks libSystem.dylib on modern macOS runners, causing
+                # "symbol not found" errors for _writev, _sysconf, etc.
+                export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=/usr/bin/cc
+                export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/usr/bin/cc
+
                 unset CC_aarch64_apple_ios_sim
                 unset CC_x86_64_apple_ios_sim
                 unset LD_aarch64_apple_ios LD_aarch64_apple_darwin LD_aarch64_apple_ios_sim


### PR DESCRIPTION
## Description 

The `react-native-pr.yml` workflow path is missing `packages/core/**` & `packages/types/**`. Since `fedimint/react-native` directly depends on both `fedimint/core` & `fedimint/types`, a breaking change to either package will be skipped the react native builds for PR check.

**Fix :-** Added missing packages to the paths in `react-native-pr.yml`. This ensures the  Android & IOS builds are triggered when their source code get changes.

Closes :- #307
