### PR TITLE
chore(ci): add fedimint-bot Codex review and agent workflows

### DIFF
--- a/.github/agents/review.md
+++ b/.github/agents/review.md
@@ -1,0 +1,286 @@
+# Automated Code Review Instructions
+
+You are reviewing a pull request in the fedimint-sdk repository. This is a
+TypeScript monorepo (pnpm workspaces) providing SDKs for building web and
+JavaScript applications on Fedimint, a federated Chaumian e-cash mint. The
+core packages wrap the Rust `fedimint-client` compiled to WebAssembly and run
+it inside a web worker with IndexedDB persistence.
+
+Repository layout:
+
+- `packages/core` — runtime-agnostic core client library
+- `packages/core-web` — browser SDK (web worker + WASM + IndexedDB)
+- `packages/transport-web` — browser transport layer
+- `packages/react` — React hooks/components
+- `packages/types` — shared TypeScript types
+- `packages/wasm-web` / `packages/wasm-bundler` — packaged WASM artifacts
+  built from the Rust `fedimint-client-wasm` crate
+- `packages/create-fedimint-app` — project scaffolding CLI
+- `packages/integration-tests` — vitest tests run against a real devimint
+  federation
+- `examples/` — example apps (vite, webpack, next, bare-js, ...)
+- `docs/` — VitePress documentation site
+
+## Review Philosophy
+
+You are a careful, security-minded TypeScript reviewer. Your job is to catch
+real bugs, not to nitpick style in isolation. Prioritize issues in this order:
+
+1. **Correctness** — logic errors, off-by-ones, mishandled edge cases,
+   msat/sat confusion, misleading comments or docs that drifted from the code.
+2. **Safety & Security** — leaking secrets or e-cash notes into logs, storage,
+   or error messages; injection; prototype pollution; unsafe `postMessage`
+   handling; dependency supply-chain risk.
+3. **Published-Package Compatibility** — breaking changes to the public API
+   of any published `@fedimint/*` package, missing changesets, or breaking
+   the coupling between the TS wrappers and the WASM bindings
+   (see Compatibility section).
+4. **Async & Resource Lifecycle** — floating promises, missing `await`,
+   unsubscribed streams, leaked workers or WASM handles, races between
+   concurrent RPC calls, operations that break when the page reloads
+   mid-flight (see Async section).
+5. **Runtime Compatibility** — code that works in one environment but breaks
+   in another (browser vs. Node, bundler differences, worker context).
+6. **API Design & Typing** — strong types over `any`/strings/bools, no
+   unjustified non-null assertions, exhaustive handling of union types.
+7. **Readability & Idiom** — reuse of existing helpers, clear naming,
+   consistent patterns across packages.
+8. **Scope** — the diff should be the minimal change that achieves its
+   stated goal; flag unrelated drive-by changes and refactors that inflate
+   the diff.
+
+**Approach**: when pushing back, phrase as a question first ("Why not …?",
+"Should we …?") and suggest a concrete alternative. Flat directives are
+reserved for true correctness or safety problems.
+
+**Completeness and validation**: include every concrete issue you find, not
+just the highest-severity ones. Prefer inline comments for all findings. The
+workflow validates candidate findings with a separate validation subagent
+before posting them; when acting as that validation subagent, keep every
+finding that is demonstrably a real problem and drop anything speculative or
+unsupported by the diff.
+
+## Dependency Bumps
+
+If the PR metadata says `PR Author: dependabot[bot]` (or the PR is otherwise a
+pure dependency bump):
+
+- Check what actually changed upstream (changelog, release notes, diff) before
+  treating the bump as low risk. npm packages can add install scripts or
+  change transitive dependencies in minor releases.
+- Be extra careful with anything that runs at install or build time
+  (`patch-package`, bundler plugins, git hooks, CI actions) — these execute
+  code on developer machines and CI runners.
+- For GitHub Actions bumps, verify the action is pinned to a full commit SHA,
+  not a mutable tag.
+- Only output `APPROVE` when the upstream changes were actually inspectable
+  and no risks were found. If the required review cannot be completed, output
+  `COMMENT` with a concise reason explaining what remains unreviewed.
+
+## Published-Package Compatibility
+
+The `@fedimint/*` packages under `packages/` are published to npm and consumed
+by downstream applications (Fedi, wallet apps, integrations). Treat their
+public API surface with the same care as a wire format.
+
+- **Changesets**: user-facing changes to published packages need a changeset
+  (`.changeset/*.md`) with the correct semver level. Removing or renaming an
+  export, changing a function signature, or changing observable behavior is
+  a breaking change and needs a major changeset — flag PRs that make such
+  changes with only a patch/minor changeset, or none at all.
+- **WASM coupling**: the TS wrappers and the WASM bindings
+  (`wasm-web` / `wasm-bundler`, built from `fedimint-client-wasm`) must agree
+  on the RPC method names, request/response shapes, and versioning. A change
+  on one side without the other is a runtime break that typecheck will not
+  catch.
+- **Persisted state**: client data lives in IndexedDB. Changes to database
+  names, store layout, or the client's persistence format must handle
+  existing users' stored state — "works on a fresh profile" is not enough.
+  Ask: what happens when a user with an existing wallet upgrades?
+- **Don't break examples silently.** Examples and `create-fedimint-app`
+  templates are the de-facto integration tests for the public API; API
+  changes should update them in the same PR.
+
+## Async & Resource Lifecycle
+
+This is the most repeated structural correctness concern for this codebase.
+
+- **Floating promises.** Every promise must be awaited, returned, or
+  explicitly fire-and-forget with error handling. An unhandled rejection in a
+  worker or event handler disappears silently in production.
+- **Subscriptions and streams must be cancellable and cleaned up.** Any
+  `subscribe*` API must return a working unsubscribe function, and internal
+  maps of callbacks must remove entries on unsubscribe — otherwise long-lived
+  apps leak memory and receive callbacks after teardown.
+- **Worker lifecycle.** Messages sent before the worker is initialized,
+  responses arriving after the client is closed, and request IDs that are
+  never resolved (leaking pending promises) are recurring bug shapes. Ask:
+  what happens to in-flight RPCs when `cleanup()` / worker termination runs?
+- **Interrupted operations are a first-class failure mode.** A browser tab
+  can be closed or reloaded at any `await` point. E-cash operations
+  (spend/reissue, deposits, withdrawals, lightning pay/receive) must either
+  be resumable from persisted state or fail safely — never leave notes in a
+  state where they are neither spendable nor recoverable.
+- **Concurrency.** Concurrent RPC calls over one worker channel must not
+  interleave incorrectly (request-ID collisions, shared mutable state).
+  Sequential `await` in a loop where parallelism is intended (or vice versa)
+  is worth flagging.
+- Timeouts and retries: network calls to federations/gateways need bounded
+  retries and timeouts; an unbounded retry loop with no backoff is a bug.
+
+## Runtime & Bundler Compatibility
+
+- `packages/core` must stay runtime-agnostic — flag browser-only globals
+  (`window`, `document`, `indexedDB`, `Worker`) leaking into it.
+- Watch for Node-only APIs (`Buffer`, `process`, `fs`) in browser-targeted
+  packages; use web-standard equivalents (`Uint8Array`, `crypto.subtle`).
+- WASM loading differs per bundler (vite vs. webpack vs. no-bundler); changes
+  to how the WASM module or worker is instantiated must work for all
+  supported setups, not just the one used to test.
+- `new URL(..., import.meta.url)` worker/asset patterns are load-bearing for
+  bundler support — treat changes to them as high risk.
+
+## Security
+
+- **Never log, persist unencrypted, or include in error messages**: e-cash
+  notes, derivation secrets, seed material, or invite-code-derived private
+  data. `console.log` of whole RPC payloads is an easy way to leak notes.
+- Validate and type `postMessage` data at the worker boundary — both sides.
+  Do not trust `event.data` shapes blindly, and never use a wildcard target
+  origin where a specific one is possible.
+- Amounts: millisatoshi values as JS `number` risk precision loss above
+  2^53; flag arithmetic on large amounts that should use `bigint` and any
+  msat/sat conversion done inline instead of via a shared helper.
+- No `eval`, `new Function`, or `innerHTML` with user-controlled data
+  (federation names, metadata, and invoice descriptions are
+  attacker-controlled inputs).
+
+## Idiomatic TypeScript Standards
+
+Prefer and suggest:
+
+- **Strong, meaningful types.** No `any` — use `unknown` plus narrowing, or a
+  proper type. String-typed fields for structured data (states, method names,
+  amounts) should be typed unions or branded types. Public boolean parameters
+  are better as options objects.
+- **No unjustified `!` non-null assertions or `as` casts.** A cast at the
+  worker/WASM boundary should be accompanied by runtime validation.
+- **Exhaustiveness.** `switch` on discriminated unions should have a
+  `never`-typed default (or satisfy exhaustiveness) so new variants fail to
+  compile instead of falling through.
+- **`async`/`await` over promise chains**; no `async` executor functions in
+  `new Promise`.
+- **Reuse existing helpers** — before accepting a new utility, check whether
+  `packages/core` or `packages/types` already has one.
+- **Errors**: throw `Error` (or subclasses), not strings; preserve the cause
+  (`new Error(msg, { cause })`) when wrapping.
+- Named constants over magic numbers; a one-line comment if the value itself
+  needs justification.
+
+## Testing
+
+- Integration tests run against a real devimint federation and may run in
+  parallel — don't assert on global federation state that another test can
+  change; make assertions order-independent.
+- Timing-based tests (`setTimeout` waits) are flaky by construction — prefer
+  awaiting the actual condition or event.
+- New public API surface on published packages should come with integration
+  test coverage, not only type-level assurance.
+- Don't assert values already exported as constants — use them directly.
+
+## What NOT to flag
+
+- Do not complain about missing documentation on internal/private items.
+- Do not suggest adding comments that merely restate what the code does
+  (comments should cover _why_ — hidden constraints, non-obvious invariants,
+  references to specs / issues).
+- Do not suggest reformatting — prettier handles formatting.
+- Do not flag loose typing or non-null assertions in test code where the
+  intent is obvious.
+- Do not suggest changes to files you haven't been shown in the diff.
+- Do not flag minor spelling / grammar in review comments or commit messages.
+
+## Severity Grading
+
+- **critical** — real bug, security issue, breaking API change without a
+  major changeset, data loss for existing users. A human _must_ address
+  before merging. Examples:
+  - "notes are removed from storage before the spend is confirmed — a reload
+    here loses funds"
+  - "renames a public export of @fedimint/core-web with only a patch
+    changeset"
+  - "logs the full RPC payload including e-cash notes"
+- **warning** — risky pattern or code smell that usually ought to be fixed
+  but might not block a merge. Examples:
+  - unsubscribe doesn't remove the callback from the internal map
+  - floating promise in a non-critical path
+  - `as` cast at the worker boundary without validation
+- **nit** — style / readability / minor helper reuse. Authors routinely take
+  or leave these. Explicitly prefix the comment body with `nit:` or `[nit]`
+  so it reads as non-blocking.
+
+## Output Format
+
+You MUST output valid JSON and nothing else. No markdown fences, no preamble,
+no explanation outside the JSON.
+
+Schema:
+
+```json
+{
+  "verdict": "APPROVE or COMMENT",
+  "compat_impact": "null, or a description of published-package / persisted-state compatibility implications that a human reviewer must evaluate.",
+  "reason": "null, or a short explanation of why the PR was not auto-approved (only when verdict is COMMENT and the reason is non-obvious).",
+  "inline_comments": [
+    {
+      "path": "relative/path/to/file.ts",
+      "line": 42,
+      "side": "RIGHT",
+      "severity": "critical | warning | nit",
+      "body": "Explanation of the issue."
+    }
+  ]
+}
+```
+
+Field details:
+
+- **verdict**: `APPROVE` — the change looks good: readable, secure, no
+  correctness issues, a minimal diff that achieves its goal, and
+  published-package compatibility is handled. Approving with a few `nit`
+  inline comments is fine and expected. `COMMENT` — use when you found
+  critical or warning-level issues, breaking changes, or genuinely cannot
+  assess the change. Never block a PR.
+- **compat_impact**: `null` if no compatibility concern. Otherwise describe
+  the specific implications a human reviewer should evaluate (e.g. "changes
+  the worker RPC request shape — requires a matching wasm-web release",
+  "changes IndexedDB store layout — existing wallets need a migration").
+  Do NOT write "None" — use `null`.
+- **reason**: `null` when approving, or when the inline comments already make
+  the reason obvious. Set this to a short sentence when the verdict is
+  COMMENT and a human needs to understand why this is not an approval.
+  Never use "LGTM" or approval-like wording when the verdict is COMMENT.
+- **inline_comments**: Array of line-level comments. All findings — bugs,
+  nits, warnings — MUST go here as inline comments, not in a top-level
+  summary. Can be empty if the change is clean. If you found multiple issues,
+  include all of them; do not suppress lower-severity validated issues just
+  because a higher-severity issue exists.
+  - **path**: File path relative to repo root, as shown in the diff.
+  - **line**: The line number in the diff to attach the comment to.
+  - **side**: `RIGHT` for lines in the new version (additions, context on new
+    side), `LEFT` for lines in the old version (deletions). When in doubt,
+    use `RIGHT`.
+  - **severity**: see the grading guide above.
+  - **body**: The comment text. Be specific and actionable. For critical /
+    warning issues, explain what could go wrong. For nits, prefix the body
+    with `nit:` / `[nit]` so the author knows it's non-blocking. Where
+    helpful, suggest the concrete alternative rather than only objecting.
+
+**Verbosity rules**: Be concise. Comments should be short, question-first
+("Why not reuse the existing subscription helper?", "What happens if the tab
+reloads here?") and often under 20 words. Do NOT write a summary of what the
+PR does — the reviewer can read the diff. Do NOT restate findings in a
+top-level body that are already covered by inline comments. The top-level
+review comment should be minimal or empty; only include information a human
+reviewer needs that cannot be expressed as an inline comment (compatibility
+implications, reasons for withholding approval).

--- a/.github/scripts/run-codex-agent.sh
+++ b/.github/scripts/run-codex-agent.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+require_env BACKPORT_TOKEN
+require_env GITHUB_ACTOR
+require_env GITHUB_EVENT_NAME
+require_env GITHUB_EVENT_PATH
+require_env GITHUB_REPOSITORY
+require_env GITHUB_WORKSPACE
+require_env PPQ_KEY
+require_env RUNNER_TEMP
+
+PPQ_MODEL="${PPQ_MODEL:-openai/gpt-5.5}"
+agent_event_name="${CODEX_AGENT_EVENT_NAME:-${GITHUB_EVENT_NAME}}"
+agent_event_path="${CODEX_AGENT_EVENT_PATH:-${GITHUB_EVENT_PATH}}"
+agent_actor="${CODEX_AGENT_ACTOR:-${GITHUB_ACTOR}}"
+
+if [ ! -s "${agent_event_path}" ]; then
+  echo "Codex agent event payload does not exist or is empty: ${agent_event_path}" >&2
+  exit 1
+fi
+
+agent_root="${RUNNER_TEMP}/codex-agent"
+agent_home="${agent_root}/home"
+codex_home="${agent_root}/codex-home"
+context_dir="${agent_root}/context"
+
+rm -rf "${agent_root}"
+mkdir -p \
+  "${agent_home}" \
+  "${codex_home}" \
+  "${context_dir}"
+
+path_toml=$(jq -Rn --arg value "${PATH}" '$value')
+
+# Security model: this job relies on the self-hosted runner's systemd
+# isolation for process containment, and on Codex's shell environment policy
+# to keep provider credentials out of agent-spawned commands.
+cat > "${codex_home}/config.toml" <<EOF
+model = "${PPQ_MODEL}"
+model_provider = "ppq"
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+
+[model_providers.ppq]
+name = "PPQ"
+base_url = "https://api.ppq.ai/v1"
+env_key = "PPQ_KEY"
+wire_api = "responses"
+
+
+[shell_environment_policy]
+inherit = "all"
+ignore_default_excludes = true
+set = { PATH = ${path_toml} }
+include_only = [
+  "PATH",
+  "HOME",
+  "CODEX_HOME",
+  "GH_TOKEN",
+  "GITHUB_API_URL",
+  "GITHUB_ACTOR",
+  "GITHUB_EVENT_NAME",
+  "GITHUB_GRAPHQL_URL",
+  "GITHUB_REPOSITORY",
+  "GITHUB_RUN_ID",
+  "GITHUB_SERVER_URL",
+  "GITHUB_WORKSPACE",
+  "RUNNER_TEMP",
+  "IN_NIX_SHELL",
+  "REPO_ROOT",
+  "NODE_*",
+  "NPM_*",
+  "npm_*",
+  "PNPM_*",
+  "COREPACK_*",
+  "PLAYWRIGHT_*",
+  "CARGO_*",
+  "RUST*",
+  "FM_*",
+  "NIX_*",
+  "NIXPKGS_*",
+  "CC*",
+  "CXX*",
+  "CFLAGS*",
+  "CPPFLAGS",
+  "PKG_CONFIG*",
+  "LD",
+  "LD_*",
+  "LD_LIBRARY_PATH",
+  "CONFIG_SHELL",
+  "SHELL",
+  "LANG",
+  "LC_*",
+  "LOCALE_ARCHIVE",
+  "TERM",
+  "TERMINFO_DIRS",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "TEMPDIR",
+  "PYTHON*",
+  "XDG_CONFIG_DIRS",
+  "XDG_DATA_DIRS",
+  "SOURCE_DATE_EPOCH",
+  "SSL_CERT_FILE",
+  "NIX_SSL_CERT_FILE",
+]
+EOF
+
+jq '{
+  action,
+  repository: env.GITHUB_REPOSITORY,
+  event_name: $event_name,
+  actor: $actor,
+  comment: .comment,
+  issue: .issue,
+  pull_request: .pull_request,
+  review: .review
+}' \
+  --arg event_name "${agent_event_name}" \
+  --arg actor "${agent_actor}" \
+  "${agent_event_path}" > "${context_dir}/event.json"
+
+cat > "${context_dir}/prompt.md" <<'EOF'
+You are fedimint-bot, an automation agent for the fedimint-sdk GitHub
+repository. fedimint-sdk is a TypeScript monorepo (pnpm workspaces)
+providing SDKs for building web applications on Fedimint, wrapping the Rust
+client compiled to WebAssembly. An organization member invoked you by
+mentioning @fedimint-bot in a GitHub issue, pull request, pull request review
+body, or pull request review thread; by opening an issue that mentions
+@fedimint-bot; or by assigning an issue to fedimint-bot. Decide what action is
+useful from the context.
+
+You may:
+- answer the question directly in the relevant GitHub thread;
+- inspect the repository, PR diff, CI state, linked issues, or previous comments;
+- do preliminary research and post findings;
+- implement a small, low-risk fix, push a branch, and open a draft PR;
+- open a follow-up issue when that is the most appropriate outcome.
+
+Use judgment. Prefer a concise answer when the user is asking a question. Only
+change code for simple, well-scoped fixes. Do not make broad refactors. Do not
+push to contributor PR branches. If you implement a fix, create a new branch
+named like `fedimint-bot/<short-topic>-<run-id>` and open a draft PR.
+
+Write GitHub comments and PR descriptions in concise, scannable Markdown:
+use short headings, bullets, code spans, and checklists when they make the
+result easier to read. Avoid wall-of-text replies, but do not add filler.
+
+Available tools:
+- `gh`, authenticated as fedimint-bot via `GH_TOKEN`;
+- `git`;
+- normal shell tools including `bash`, `curl`, `jq`, `rg`, `sed`, and `awk`;
+- the repository's Nix development shell is active, including `node`, `pnpm`,
+  and the devimint test environment used by the integration tests.
+
+Repository conventions:
+- Follow any repository instructions (e.g. `.github/CONTRIBUTING.md`) and
+  nested package READMEs.
+- Use `pnpm` (never npm or yarn); dependencies are installed with
+  `pnpm install`.
+- Avoid `any`; use strong types. Prefer `async`/`await` and make sure
+  promises are awaited or explicitly handled.
+- User-facing changes to published `packages/*` need a changeset
+  (`pnpm changeset`) with an appropriate semver level.
+- Run `pnpm lint:fix` (prettier) after code changes.
+- Run focused checks when practical (`pnpm typecheck`, `pnpm build`, or a
+  targeted vitest run) and report what was or was not verified.
+
+Operational rules:
+- The GitHub event payload is at `$RUNNER_TEMP/codex-agent/context/event.json`.
+- The checked out repository is at `$GITHUB_WORKSPACE`.
+- The checkout includes recent history using partial clone filtering
+  (`fetch-depth: 50` with `filter: blob:none`) to keep startup fast while
+  preserving local context for common history lookups. If you need older
+  history, tags, or PR refs, fetch only the specific refs you need.
+- First inspect the normalized `event_name` field in the event payload to
+  understand whether this is an issue event, issue comment, PR comment,
+  submitted PR review, or inline PR review comment. Submitted PR reviews and
+  inline PR review comments may arrive through a privileged follow-up workflow,
+  but their payloads are normalized to `pull_request_review` or
+  `pull_request_review_comment`.
+- Use `gh` to fetch additional context as needed.
+- For issue assignment events, treat the assignment as a request to open a
+  small draft PR when the issue is well scoped and implementation is low risk.
+- For inline PR review comments, get the pull request number from the event
+  payload and use `gh api
+  repos/:owner/:repo/pulls/:pull_number/comments/:comment_id/replies
+  -f body=...` to reply directly to the review thread.
+- If replying to an inline PR review comment returns 404, do not immediately
+  fall back to a top-level PR comment. First fetch all review comments for the
+  PR with `gh api --paginate repos/:owner/:repo/pulls/:pull_number/comments`,
+  search for the event comment by `id`, `node_id`, `html_url`, file location,
+  and body text, then retry the reply using the matched comment id if found.
+- If responding to a pull request review comment, prefer replying to that
+  review comment thread when possible. Otherwise comment on the issue or PR.
+- If responding to a submitted pull request review body, prefer a top-level PR
+  comment because GitHub does not expose a review-body reply thread.
+- Before finishing, post a GitHub comment/reply, open a GitHub issue, or open a
+  draft PR, unless the safest action is explicitly to do nothing.
+- If you cannot complete the requested action, post a short comment explaining
+  the blocker.
+- Avoid mentioning secrets or environment variable values in comments, logs,
+  commits, branches, or PR descriptions.
+- Do not wait for human input; make a reasonable decision and act.
+EOF
+
+export HOME="${agent_home}"
+export CODEX_HOME="${codex_home}"
+export GH_TOKEN="${BACKPORT_TOKEN}"
+
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+git config --global user.name fedimint-bot
+git config --global user.email fedimint-bot@users.noreply.github.com
+gh auth status >/dev/null
+gh auth setup-git
+
+cd "${GITHUB_WORKSPACE}"
+# Deliberately bypass Codex's own sandbox here: the dedicated runner service
+# provides systemd isolation, and shell_environment_policy keeps model/API
+# secrets out of commands the agent runs.
+exec codex exec \
+  --ephemeral \
+  --dangerously-bypass-approvals-and-sandbox \
+  "$(cat "${context_dir}/prompt.md")"

--- a/.github/scripts/run-codex-ci-debug.sh
+++ b/.github/scripts/run-codex-ci-debug.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+require_env BACKPORT_TOKEN
+require_env CI_DEBUG_RUN_ID
+require_env CI_DEBUG_RUN_URL
+require_env GITHUB_ACTOR
+require_env GITHUB_EVENT_NAME
+require_env GITHUB_EVENT_PATH
+require_env GITHUB_REPOSITORY
+require_env GITHUB_WORKSPACE
+require_env PPQ_KEY
+require_env PPQ_MODEL
+require_env RUNNER_TEMP
+
+# Workflow-dispatch runs intentionally leave some CI_DEBUG_* values empty.
+# Only require the fields needed to identify and fetch the target run.
+
+agent_root="${RUNNER_TEMP}/codex-ci-debug"
+agent_home="${agent_root}/home"
+codex_home="${agent_root}/codex-home"
+context_dir="${agent_root}/context"
+
+rm -rf "${agent_root}"
+mkdir -p \
+  "${agent_home}" \
+  "${codex_home}" \
+  "${context_dir}"
+
+path_toml=$(jq -Rn --arg value "${PATH}" '$value')
+
+cat > "${codex_home}/config.toml" <<EOF
+model = "${PPQ_MODEL}"
+model_provider = "ppq"
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+
+[model_providers.ppq]
+name = "PPQ"
+base_url = "https://api.ppq.ai/v1"
+env_key = "PPQ_KEY"
+wire_api = "responses"
+
+
+[shell_environment_policy]
+inherit = "all"
+ignore_default_excludes = true
+set = { PATH = ${path_toml} }
+include_only = [
+  "PATH",
+  "HOME",
+  "CODEX_HOME",
+  "GH_TOKEN",
+  "GITHUB_API_URL",
+  "GITHUB_ACTOR",
+  "GITHUB_EVENT_NAME",
+  "GITHUB_GRAPHQL_URL",
+  "GITHUB_REPOSITORY",
+  "GITHUB_RUN_ID",
+  "GITHUB_SERVER_URL",
+  "GITHUB_WORKSPACE",
+  "RUNNER_TEMP",
+  "CI_DEBUG_RUN_ID",
+  "CI_DEBUG_RUN_URL",
+  "CI_DEBUG_WORKFLOW_NAME",
+  "CI_DEBUG_WORKFLOW_EVENT",
+  "CI_DEBUG_HEAD_BRANCH",
+  "CI_DEBUG_HEAD_SHA",
+  "IN_NIX_SHELL",
+  "REPO_ROOT",
+  "NODE_*",
+  "NPM_*",
+  "npm_*",
+  "PNPM_*",
+  "COREPACK_*",
+  "PLAYWRIGHT_*",
+  "CARGO_*",
+  "RUST*",
+  "FM_*",
+  "NIX_*",
+  "NIXPKGS_*",
+  "CC*",
+  "CXX*",
+  "CFLAGS*",
+  "CPPFLAGS",
+  "PKG_CONFIG*",
+  "LD",
+  "LD_*",
+  "LD_LIBRARY_PATH",
+  "CONFIG_SHELL",
+  "SHELL",
+  "LANG",
+  "LC_*",
+  "LOCALE_ARCHIVE",
+  "TERM",
+  "TERMINFO_DIRS",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "TEMPDIR",
+  "PYTHON*",
+  "XDG_CONFIG_DIRS",
+  "XDG_DATA_DIRS",
+  "SOURCE_DATE_EPOCH",
+  "SSL_CERT_FILE",
+  "NIX_SSL_CERT_FILE",
+]
+EOF
+
+jq '{
+  action,
+  repository: env.GITHUB_REPOSITORY,
+  event_name: env.GITHUB_EVENT_NAME,
+  actor: env.GITHUB_ACTOR,
+  workflow_run: .workflow_run,
+  inputs: .inputs
+}' "${GITHUB_EVENT_PATH}" > "${context_dir}/event.json"
+
+cat > "${context_dir}/prompt.md" <<'EOF'
+You are fedimint-bot, an automation agent for failed fedimint-sdk CI runs.
+A GitHub Actions workflow failed on the main branch. Investigate the failure
+and either comment on the culprit pull request, document unresolved findings
+in a GitHub issue, or open a draft pull request with a small, well-scoped fix.
+
+fedimint-sdk is a TypeScript monorepo (pnpm workspaces) providing SDKs for
+building web applications on Fedimint, wrapping the Rust client compiled to
+WebAssembly.
+
+Target run:
+- Run id: $CI_DEBUG_RUN_ID
+- Run URL: $CI_DEBUG_RUN_URL
+- Workflow: $CI_DEBUG_WORKFLOW_NAME
+- Event: $CI_DEBUG_WORKFLOW_EVENT
+- Head branch: $CI_DEBUG_HEAD_BRANCH
+- Head SHA: $CI_DEBUG_HEAD_SHA
+
+Use the GitHub event payload at:
+$RUNNER_TEMP/codex-ci-debug/context/event.json
+
+Available tools:
+- `gh`, authenticated as fedimint-bot via `GH_TOKEN`;
+- `git`;
+- normal shell tools including `bash`, `curl`, `jq`, `rg`, `sed`, and `awk`;
+- the repository's Nix development shell is active, including `node`, `pnpm`,
+  and the devimint test environment used by the integration tests.
+
+Baseline investigation:
+- Start with `gh run view "$CI_DEBUG_RUN_ID" --repo "$GITHUB_REPOSITORY"` and
+  `gh api repos/:owner/:repo/actions/runs/$CI_DEBUG_RUN_ID/jobs --paginate`.
+- Find the real failed job/step. Fetch focused logs for the failing jobs with
+  `gh run view --job <job-id> --log`. Search for `FAIL`, `error`, `ELIFECYCLE`,
+  `timed out`, and the failing test or package name.
+- Identify the commit or PR that landed on main before the failure
+  (`git log`, `gh pr list --search <sha>`) and compare the failure with those
+  changes before deciding whether this is a repository-level failure or a
+  legitimate bug in the merged PR.
+- Check recent history for the same failure using `gh run list`,
+  `gh issue list/search`, and `gh pr list/search` before opening duplicate
+  issues or PRs.
+- Always search for existing GitHub issues tracking the same failure before
+  opening a new issue. Update the existing issue instead when there is a clear
+  match.
+
+Common failure categories in this repository:
+- The "Changesets" workflow handles versioning and npm publishing — failures
+  are often npm auth/registry errors, changeset misconfiguration, or a package
+  that no longer builds. Treat clear upstream registry HTTP 5xx failures as
+  transient unless they recur enough to justify a retry/caching fix.
+- Integration tests run vitest against a real devimint federation and can be
+  flaky for timing reasons; a flaky failure still needs to be debugged and
+  fixed when there is a high-confidence cause.
+- Docs deployment failures are usually VitePress build errors introduced by a
+  recently merged docs or API change.
+
+Decision rules:
+- Open a draft PR only when the fix is concrete, low-risk, and can be validated
+  with a focused command. Create a branch named
+  `fedimint-bot/ci-debug-<short-topic>-$CI_DEBUG_RUN_ID`.
+- Do not open an issue merely because a failure is flaky; only when the
+  investigation cannot establish a high-confidence cause or actionable fix,
+  when the cause is external/operational and needs tracking rather than a code
+  change, or when maintainer input is required. Include the failing run URL,
+  failed job and step, concise log excerpts, and a concrete next action.
+- Reuse or update an existing issue/PR when one already clearly tracks the same
+  failure. Avoid duplicate issues.
+- If the failure is caused by a legitimate bug in a recently merged PR, comment
+  on that PR with the failed run URL, failing job and step, concise evidence,
+  and what needs to be fixed in a follow-up.
+- Run `pnpm lint:fix` after code changes when available, plus the smallest
+  useful check (`pnpm typecheck`, `pnpm build`, or a targeted vitest run).
+  Report any checks that were skipped and why in the issue or PR.
+- Avoid broad refactors and do not change unrelated code.
+- Do not mention secrets or environment variable values in comments, issues,
+  commits, branches, or PR descriptions.
+- Before finishing, comment on the culprit PR, open or update a GitHub issue,
+  or open a draft PR. If you cannot complete one of those actions, open an issue
+  explaining the blocker.
+EOF
+
+envsubst < "${context_dir}/prompt.md" > "${context_dir}/prompt.expanded.md"
+
+export HOME="${agent_home}"
+export CODEX_HOME="${codex_home}"
+export GH_TOKEN="${BACKPORT_TOKEN}"
+
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+git config --global user.name fedimint-bot
+git config --global user.email fedimint-bot@users.noreply.github.com
+gh auth status >/dev/null
+gh auth setup-git
+
+cd "${GITHUB_WORKSPACE}"
+exec codex exec \
+  --ephemeral \
+  --dangerously-bypass-approvals-and-sandbox \
+  "$(cat "${context_dir}/prompt.expanded.md")"

--- a/.github/workflows/codex-agent-review-comment-receiver.yml
+++ b/.github/workflows/codex-agent-review-comment-receiver.yml
@@ -1,0 +1,119 @@
+name: 'Codex Agent Review Comment Receiver'
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.comment.id || github.event.review.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  receive:
+    name: Receive review mention
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.repository == 'fedimint/fedimint-sdk' &&
+      github.actor != 'fedimint-bot' &&
+      github.actor != 'github-actions[bot]'
+
+    steps:
+      - name: Capture sanitized event
+        id: capture
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request_review" ]; then
+            body=$(jq -r '.review.body // ""' "${GITHUB_EVENT_PATH}")
+            mention_source="review body"
+          else
+            body=$(jq -r '.comment.body // ""' "${GITHUB_EVENT_PATH}")
+            mention_source="review comment"
+          fi
+
+          if [[ "${body}" != *"@fedimint-bot"* ]]; then
+            echo "upload=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping: ${mention_source} does not mention @fedimint-bot"
+            exit 0
+          fi
+
+          mkdir -p "${RUNNER_TEMP}/codex-agent-review"
+          # This workflow intentionally has no secrets on fork PRs. It only
+          # carries enough context for the default-branch workflow_run handler
+          # to re-fetch and re-validate the live review object before using secrets.
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request_review" ]; then
+            jq --arg event_name "${GITHUB_EVENT_NAME}" '{
+              event_name: $event_name,
+              action,
+              review: {
+                id: .review.id,
+                node_id: .review.node_id,
+                body: .review.body,
+                html_url: .review.html_url,
+                pull_request_url: .review.pull_request_url,
+                state: .review.state,
+                user: { login: .review.user.login },
+                author_association: .review.author_association
+              },
+              pull_request: {
+                number: .pull_request.number,
+                html_url: .pull_request.html_url,
+                url: .pull_request.url,
+                base: {
+                  ref: .pull_request.base.ref,
+                  sha: .pull_request.base.sha,
+                  repo: { full_name: .pull_request.base.repo.full_name }
+                },
+                head: {
+                  ref: .pull_request.head.ref,
+                  sha: .pull_request.head.sha,
+                  repo: { full_name: .pull_request.head.repo.full_name }
+                }
+              },
+              sender: { login: .sender.login }
+            }' "${GITHUB_EVENT_PATH}" > "${RUNNER_TEMP}/codex-agent-review/event.json"
+          else
+            jq --arg event_name "${GITHUB_EVENT_NAME}" '{
+              event_name: $event_name,
+              action,
+              comment: {
+                id: .comment.id,
+                node_id: .comment.node_id,
+                body: .comment.body,
+                html_url: .comment.html_url,
+                pull_request_url: .comment.pull_request_url,
+                user: { login: .comment.user.login },
+                author_association: .comment.author_association
+              },
+              pull_request: {
+                number: .pull_request.number,
+                html_url: .pull_request.html_url,
+                url: .pull_request.url,
+                base: {
+                  ref: .pull_request.base.ref,
+                  sha: .pull_request.base.sha,
+                  repo: { full_name: .pull_request.base.repo.full_name }
+                },
+                head: {
+                  ref: .pull_request.head.ref,
+                  sha: .pull_request.head.sha,
+                  repo: { full_name: .pull_request.head.repo.full_name }
+                }
+              },
+              sender: { login: .sender.login }
+            }' "${GITHUB_EVENT_PATH}" > "${RUNNER_TEMP}/codex-agent-review/event.json"
+          fi
+          echo "upload=true" >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: steps.capture.outputs.upload == 'true'
+        with:
+          name: codex-agent-review-event
+          path: ${{ runner.temp }}/codex-agent-review/event.json
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/codex-agent.yml
+++ b/.github/workflows/codex-agent.yml
@@ -1,0 +1,391 @@
+name: 'Codex Agent'
+
+on:
+  issues:
+    types: [opened, assigned]
+  issue_comment:
+    types: [created]
+  workflow_run:
+    workflows: ['Codex Agent Review Comment Receiver']
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.workflow_run.id || github.event.comment.id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  agent:
+    name: Run Codex agent
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 120
+    if: >-
+      github.repository == 'fedimint/fedimint-sdk' &&
+      ((github.event_name == 'issues' &&
+        github.actor != 'fedimint-bot' &&
+        github.actor != 'github-actions[bot]' &&
+        (github.event.action == 'opened' ||
+         (github.event.action == 'assigned' &&
+          github.event.assignee.login == 'fedimint-bot'))) ||
+       (github.event_name == 'issue_comment' &&
+        github.actor != 'fedimint-bot' &&
+        github.actor != 'github-actions[bot]') ||
+       (github.event_name == 'workflow_run' &&
+        (github.event.workflow_run.event == 'pull_request_review' ||
+         github.event.workflow_run.event == 'pull_request_review_comment') &&
+        github.event.workflow_run.conclusion == 'success'))
+
+    steps:
+      - name: Validate agent mention
+        id: validate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+        run: |
+          set -euo pipefail
+          nix --extra-experimental-features 'nix-command flakes' \
+            --accept-flake-config \
+            shell \
+            nixpkgs#jq \
+            nixpkgs#curl \
+            nixpkgs#unzip \
+            nixpkgs#gh \
+            -c bash <<'BASH'
+          set -euo pipefail
+
+          api_url="${GITHUB_API_URL:-https://api.github.com}"
+          event_payload="${GITHUB_EVENT_PATH}"
+          event_name="${EVENT_NAME}"
+          comment_endpoint=""
+          comment_user=""
+          comment_id=""
+          issue_number=""
+          request_kind="${event_name}"
+          body=""
+          artifact_dir=""
+
+          if [ "${event_name}" = "workflow_run" ]; then
+            # The receiver may have run without secrets on a fork PR. Treat its
+            # artifact as untrusted and use it only to find the live review
+            # object, then re-check the mention and reviewer membership here.
+            artifacts_url=$(jq -r '.workflow_run.artifacts_url // ""' "${GITHUB_EVENT_PATH}")
+            if [ -z "${artifacts_url}" ]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: workflow_run event has no artifacts URL"
+              exit 0
+            fi
+
+            artifact_id=$(gh api "${artifacts_url}" \
+              --jq '.artifacts[] | select(.name == "codex-agent-review-event" or .name == "codex-agent-review-comment-event") | .id' \
+              | head -n1)
+
+            if [ -z "${artifact_id}" ]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: receiver uploaded no review event artifact"
+              exit 0
+            fi
+
+            artifact_dir="${RUNNER_TEMP}/codex-agent-review-artifact"
+            rm -rf "${artifact_dir}"
+            mkdir -p "${artifact_dir}"
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" \
+              > "${artifact_dir}/artifact.zip"
+            unzip -q "${artifact_dir}/artifact.zip" -d "${artifact_dir}"
+
+            event_payload="${artifact_dir}/event.json"
+            if [ ! -s "${event_payload}" ]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: review event artifact is missing event.json"
+              exit 0
+            fi
+
+            request_kind=$(jq -r '.event_name // ""' "${event_payload}")
+            if [ -z "${request_kind}" ]; then
+              if jq -e '.comment.id?' "${event_payload}" >/dev/null; then
+                request_kind="pull_request_review_comment"
+              elif jq -e '.review.id?' "${event_payload}" >/dev/null; then
+                request_kind="pull_request_review"
+              fi
+            fi
+
+            if [ "${request_kind}" = "pull_request_review_comment" ]; then
+              comment_id=$(jq -r '.comment.id // ""' "${event_payload}")
+              if ! [[ "${comment_id}" =~ ^[0-9]+$ ]]; then
+                echo "run=false" >> "${GITHUB_OUTPUT}"
+                echo "Skipping: review-comment artifact has invalid comment id"
+                exit 0
+              fi
+
+              comment_endpoint="repos/${GITHUB_REPOSITORY}/pulls/comments/${comment_id}"
+            elif [ "${request_kind}" = "pull_request_review" ]; then
+              comment_id=$(jq -r '.review.id // ""' "${event_payload}")
+              pull_number=$(jq -r '.pull_request.number // ""' "${event_payload}")
+              if ! [[ "${comment_id}" =~ ^[0-9]+$ ]]; then
+                echo "run=false" >> "${GITHUB_OUTPUT}"
+                echo "Skipping: review artifact has invalid review id"
+                exit 0
+              fi
+              if ! [[ "${pull_number}" =~ ^[0-9]+$ ]]; then
+                echo "run=false" >> "${GITHUB_OUTPUT}"
+                echo "Skipping: review artifact has invalid pull request number"
+                exit 0
+              fi
+
+              comment_endpoint="repos/${GITHUB_REPOSITORY}/pulls/${pull_number}/reviews/${comment_id}"
+            else
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: review artifact has unsupported event_name=${request_kind:-<missing>}"
+              exit 0
+            fi
+          elif [ "${event_name}" = "issue_comment" ]; then
+            body=$(jq -r '.comment.body // ""' "${event_payload}")
+            comment_id=$(jq -r '.comment.id // ""' "${event_payload}")
+            comment_user=$(jq -r '.comment.user.login // ""' "${event_payload}")
+            author_association=$(jq -r '.comment.author_association // ""' "${event_payload}")
+
+            echo "event=${event_name}"
+            echo "comment_id=${comment_id}"
+            echo "comment_user=${comment_user}"
+            echo "author_association=${author_association:-<missing>}"
+
+            if [[ "${body}" != *"@fedimint-bot"* ]]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: comment does not mention @fedimint-bot"
+              exit 0
+            fi
+
+            comment_endpoint="repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}"
+          else
+            issue_number=$(jq -r '.issue.number // ""' "${event_payload}")
+            comment_id="${issue_number}"
+            action=$(jq -r '.action // ""' "${event_payload}")
+            assignee=$(jq -r '.assignee.login // ""' "${event_payload}")
+            title=$(jq -r '.issue.title // ""' "${event_payload}")
+            body=$(jq -r '.issue.body // ""' "${event_payload}")
+            issue_text=$(printf '%s\n%s' "${title}" "${body}")
+            comment_user=$(jq -r '.sender.login // env.GITHUB_ACTOR' "${event_payload}")
+            author_association=$(jq -r '.issue.author_association // ""' "${event_payload}")
+
+            echo "event=${event_name}"
+            echo "action=${action}"
+            echo "issue_number=${issue_number}"
+            echo "request_user=${comment_user}"
+            echo "author_association=${author_association:-<missing>}"
+
+            if ! [[ "${issue_number}" =~ ^[0-9]+$ ]]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: issues event has invalid issue number"
+              exit 0
+            fi
+
+            if [ "${action}" = "opened" ] && [[ "${issue_text}" != *"@fedimint-bot"* ]]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: opened issue does not mention @fedimint-bot"
+              exit 0
+            fi
+
+            if [ "${action}" = "assigned" ] && [ "${assignee}" != "fedimint-bot" ]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: issue was not assigned to fedimint-bot"
+              exit 0
+            fi
+
+            comment_endpoint="repos/${GITHUB_REPOSITORY}/issues/${issue_number}"
+          fi
+
+          live_comment=$(curl --fail-with-body --silent --show-error \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${api_url}/${comment_endpoint}")
+
+          body=$(jq -r '.body // ""' <<<"${live_comment}")
+          live_author_association=$(jq -r '.author_association // ""' <<<"${live_comment}")
+          if [ "${event_name}" != "issues" ]; then
+            comment_user=$(jq -r '.user.login // ""' <<<"${live_comment}")
+          fi
+
+          echo "event=${event_name}"
+          echo "comment_id=${comment_id}"
+          echo "comment_user=${comment_user}"
+          echo "live_author_association=${live_author_association:-<missing>}"
+
+          if [ "${event_name}" = "issues" ]; then
+            action=$(jq -r '.action // ""' "${event_payload}")
+            assignee=$(jq -r '.assignee.login // ""' "${event_payload}")
+            title=$(jq -r '.title // ""' <<<"${live_comment}")
+            issue_text=$(printf '%s\n%s' "${title}" "${body}")
+
+            if [ "${action}" = "opened" ] && [[ "${issue_text}" != *"@fedimint-bot"* ]]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: live issue does not mention @fedimint-bot"
+              exit 0
+            fi
+
+            if [ "${action}" = "assigned" ] && [ "${assignee}" != "fedimint-bot" ]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: issue assignment event is not for fedimint-bot"
+              exit 0
+            fi
+
+            if [ "${action}" = "assigned" ] && ! jq -e '.assignees[]? | select(.login == "fedimint-bot")' <<<"${live_comment}" >/dev/null; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: live issue is no longer assigned to fedimint-bot"
+              exit 0
+            fi
+          elif [[ "${body}" != *"@fedimint-bot"* ]]; then
+            echo "run=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping: live comment does not mention @fedimint-bot"
+            exit 0
+          fi
+
+          reviewer_membership=$(
+            curl --silent --show-error \
+              --write-out '%{http_code}' \
+              --output /tmp/fedimint-bot-reviewer-membership.json \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "${api_url}/orgs/fedimint/teams/reviewers/memberships/${comment_user}"
+          )
+
+          if [ "${reviewer_membership}" = "200" ]; then
+            membership_state=$(jq -r '.state // ""' /tmp/fedimint-bot-reviewer-membership.json)
+          else
+            membership_state=""
+          fi
+
+          echo "reviewer_membership_status=${reviewer_membership}"
+          echo "reviewer_membership_state=${membership_state:-<missing>}"
+
+          if [ "${membership_state}" != "active" ]; then
+            echo "run=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping: requester is not an active fedimint/reviewers team member"
+            exit 0
+          fi
+
+          agent_event_path="${RUNNER_TEMP}/codex-agent-event.json"
+
+          if [ "${event_name}" = "workflow_run" ]; then
+            pull_request_url=$(jq -r '.pull_request_url // ""' <<<"${live_comment}")
+            if [ -z "${pull_request_url}" ] || [ "${pull_request_url}" = "null" ]; then
+              echo "run=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping: live review object has no pull_request_url"
+              exit 0
+            fi
+
+            pull_request=$(curl --fail-with-body --silent --show-error \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "${pull_request_url}")
+
+            if [ "${request_kind}" = "pull_request_review_comment" ]; then
+              jq -n \
+                --argjson comment "${live_comment}" \
+                --argjson pull_request "${pull_request}" \
+                '{
+                  action: "created",
+                  comment: $comment,
+                  pull_request: $pull_request
+                }' > "${agent_event_path}"
+              echo "agent_event_name=pull_request_review_comment" >> "${GITHUB_OUTPUT}"
+            else
+              jq -n \
+                --argjson review "${live_comment}" \
+                --argjson pull_request "${pull_request}" \
+                '{
+                  action: "submitted",
+                  review: $review,
+                  pull_request: $pull_request
+                }' > "${agent_event_path}"
+              echo "agent_event_name=pull_request_review" >> "${GITHUB_OUTPUT}"
+            fi
+            echo "agent_actor=${comment_user}" >> "${GITHUB_OUTPUT}"
+          else
+            cp "${event_payload}" "${agent_event_path}"
+            echo "agent_event_name=${event_name}" >> "${GITHUB_OUTPUT}"
+            echo "agent_actor=${comment_user}" >> "${GITHUB_OUTPUT}"
+          fi
+
+          echo "agent_event_path=${agent_event_path}" >> "${GITHUB_OUTPUT}"
+          echo "comment_id=${comment_id}" >> "${GITHUB_OUTPUT}"
+          echo "comment_kind=${request_kind}" >> "${GITHUB_OUTPUT}"
+          echo "run=true" >> "${GITHUB_OUTPUT}"
+          echo "Trigger accepted"
+          BASH
+
+      - name: Acknowledge request
+        if: steps.validate.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+          COMMENT_ID: ${{ steps.validate.outputs.comment_id }}
+          COMMENT_KIND: ${{ steps.validate.outputs.comment_kind }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          nix --extra-experimental-features 'nix-command flakes' \
+            --accept-flake-config \
+            shell \
+            nixpkgs#curl \
+            -c bash <<'BASH'
+          set -euo pipefail
+          api_url="${GITHUB_API_URL:-https://api.github.com}"
+
+          if [ "${COMMENT_KIND}" = "pull_request_review_comment" ]; then
+            endpoint="repos/${REPOSITORY}/pulls/comments/${COMMENT_ID}/reactions"
+          elif [ "${COMMENT_KIND}" = "pull_request_review" ]; then
+            echo "Skipping reaction: pull request reviews do not have a supported reactions endpoint"
+            exit 0
+          elif [ "${COMMENT_KIND}" = "issues" ]; then
+            endpoint="repos/${REPOSITORY}/issues/${COMMENT_ID}/reactions"
+          else
+            endpoint="repos/${REPOSITORY}/issues/comments/${COMMENT_ID}/reactions"
+          fi
+
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${api_url}/${endpoint}" \
+            --data '{"content":"eyes"}' \
+            >/dev/null
+          BASH
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: steps.validate.outputs.run == 'true'
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 50
+          filter: blob:none
+          persist-credentials: false
+
+      - name: Run Codex in Fedimint dev shell
+        if: steps.validate.outputs.run == 'true'
+        env:
+          BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+          CODEX_AGENT_ACTOR: ${{ steps.validate.outputs.agent_actor }}
+          CODEX_AGENT_EVENT_NAME: ${{ steps.validate.outputs.agent_event_name }}
+          CODEX_AGENT_EVENT_PATH: ${{ steps.validate.outputs.agent_event_path }}
+          PPQ_KEY: ${{ secrets.PPQ_KEY }}
+          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
+        run: |
+          set -euo pipefail
+          nix --extra-experimental-features 'nix-command flakes' \
+            --accept-flake-config \
+            develop \
+            .#default \
+            --command \
+            nix --extra-experimental-features 'nix-command flakes' \
+            --accept-flake-config \
+            shell \
+            github:numtide/llm-agents.nix/24ec6b7b1ddf8896ac8df3b65dc564575e0a1928#codex \
+            nixpkgs#gh \
+            nixpkgs#ripgrep \
+            nixpkgs#curl \
+            -c bash .github/scripts/run-codex-agent.sh

--- a/.github/workflows/codex-ci-debug.yml
+++ b/.github/workflows/codex-ci-debug.yml
@@ -1,0 +1,121 @@
+name: 'Codex CI Debug'
+
+on:
+  workflow_run:
+    workflows:
+      - 'Changesets'
+      - 'Deploy Docs site to Pages'
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'GitHub Actions run id to debug'
+        required: true
+      reason:
+        description: 'Optional context for the manual debug run'
+        required: false
+        default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id || inputs.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  debug:
+    name: Debug failed CI run
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 120
+    if: >-
+      github.repository == 'fedimint/fedimint-sdk' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'failure' &&
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_branch == 'main'
+        )
+      )
+
+    steps:
+      - name: Select failed run
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_DISPATCH_RUN_ID: ${{ inputs.run_id }}
+          WORKFLOW_DISPATCH_REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            run_id="${WORKFLOW_DISPATCH_RUN_ID}"
+            run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+            run_name="manual"
+            run_event="manual"
+            head_branch=""
+            head_sha=""
+          else
+            run_id="${WORKFLOW_RUN_ID}"
+            run_url="${WORKFLOW_RUN_URL}"
+            run_name="${WORKFLOW_RUN_NAME}"
+            run_event="${WORKFLOW_RUN_EVENT}"
+            head_branch="${WORKFLOW_RUN_HEAD_BRANCH}"
+            head_sha="${WORKFLOW_RUN_HEAD_SHA}"
+          fi
+
+          {
+            echo "run_id=${run_id}"
+            echo "run_url=${run_url}"
+            echo "run_name=${run_name}"
+            echo "run_event=${run_event}"
+            echo "head_branch=${head_branch}"
+            echo "head_sha=${head_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "Selected CI run ${run_id}: ${run_url}"
+          if [ -n "${WORKFLOW_DISPATCH_REASON}" ]; then
+            echo "Manual context: ${WORKFLOW_DISPATCH_REASON}"
+          fi
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Codex CI debugger
+        env:
+          BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+          CI_DEBUG_RUN_ID: ${{ steps.target.outputs.run_id }}
+          CI_DEBUG_RUN_URL: ${{ steps.target.outputs.run_url }}
+          CI_DEBUG_WORKFLOW_NAME: ${{ steps.target.outputs.run_name }}
+          CI_DEBUG_WORKFLOW_EVENT: ${{ steps.target.outputs.run_event }}
+          CI_DEBUG_HEAD_BRANCH: ${{ steps.target.outputs.head_branch }}
+          CI_DEBUG_HEAD_SHA: ${{ steps.target.outputs.head_sha }}
+          PPQ_KEY: ${{ secrets.PPQ_KEY }}
+          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
+        run: |
+          set -euo pipefail
+          nix --extra-experimental-features 'nix-command flakes' \
+            --accept-flake-config \
+            develop \
+            .#default \
+            --command \
+            nix --extra-experimental-features 'nix-command flakes' \
+            --accept-flake-config \
+            shell \
+            github:numtide/llm-agents.nix/24ec6b7b1ddf8896ac8df3b65dc564575e0a1928#codex \
+            nixpkgs#gh \
+            nixpkgs#ripgrep \
+            nixpkgs#curl \
+            nixpkgs#jq \
+            nixpkgs#gettext \
+            -c bash .github/scripts/run-codex-ci-debug.sh

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,548 @@
+name: 'Codex PR Review'
+
+on:
+  # Use pull_request_target so secrets are available for fork PRs.
+  # Safety: we checkout the base branch (trusted) and only fetch the PR
+  # diff as text — no untrusted code is checked out or executed.
+  pull_request_target:
+    types: [opened, ready_for_review, review_requested]
+  # Re-review only when explicitly requested via "/review" comment on a PR
+  issue_comment:
+    types: [created]
+
+# One review per PR at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  review:
+    # Run on PR open/ready-for-review, when fedimint-bot is requested for
+    # review, or when someone comments "/review" on a PR
+    if: >-
+      github.repository == 'fedimint/fedimint-sdk' && (
+        (github.event_name == 'pull_request_target' && !github.event.pull_request.draft &&
+         (github.event.action != 'review_requested' ||
+          github.event.requested_reviewer.login == 'fedimint-bot')) ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+         contains(github.event.comment.body, '/review'))
+      )
+    name: Codex Code Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Resolve PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER="${{ github.event.issue.number }}"
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          fi
+
+          # Fetch full PR data from the API (works uniformly for both triggers)
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(echo "$PR_JSON" | jq -r '.base.ref')" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(echo "$PR_JSON" | jq -r '.base.sha')" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(echo "$PR_JSON" | jq -r '.head.sha')" >> "$GITHUB_OUTPUT"
+          echo "author_login=$(echo "$PR_JSON" | jq -r '.user.login')" >> "$GITHUB_OUTPUT"
+          echo "title=$(echo "$PR_JSON" | jq -r '.title')" >> "$GITHUB_OUTPUT"
+
+      - name: Acknowledge review request
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+        run: |
+          gh api \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            --method POST \
+            -f content='eyes'
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Checkout the base branch (trusted code only)
+          ref: ${{ steps.pr.outputs.base_ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch PR head
+        run: |
+          # Fetch the PR head commit without checking it out
+          git fetch origin "${{ steps.pr.outputs.head_sha }}"
+
+      - name: Get diff for review
+        id: diff
+        run: |
+          BASE_SHA=${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA=${{ steps.pr.outputs.head_sha }}
+
+          git diff "$BASE_SHA"..."$HEAD_SHA" > /tmp/pr_diff.patch
+
+          DIFF_SIZE=$(wc -c < /tmp/pr_diff.patch)
+          MAX_SIZE=200000
+          if [ "$DIFF_SIZE" -gt "$MAX_SIZE" ]; then
+            truncate -s "$MAX_SIZE" /tmp/pr_diff.patch
+            echo -e "\n\n... [diff truncated at ${MAX_SIZE} bytes, full diff is ${DIFF_SIZE} bytes] ..." >> /tmp/pr_diff.patch
+            echo "truncated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "truncated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Fetch prior AI reviews
+        id: prior
+        env:
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+
+          # Determine the bot account login from the token
+          BOT_LOGIN=$(gh api user --jq '.login')
+
+          # Fetch all reviews on this PR by the bot account
+          PRIOR=$(gh api \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+            --jq "[.[] | select(.user.login == \"${BOT_LOGIN}\") | {submitted_at, body, state}] | sort_by(.submitted_at)")
+
+          PRIOR_COUNT=$(echo "$PRIOR" | jq 'length')
+
+          if [ "$PRIOR_COUNT" -gt 0 ]; then
+            echo "has_prior=true" >> "$GITHUB_OUTPUT"
+            # Also grab inline comments from the bot
+            PRIOR_COMMENTS=$(gh api \
+              "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
+              --jq "[.[] | select(.user.login == \"${BOT_LOGIN}\") | {path, line, side, body, created_at}] | sort_by(.created_at)")
+
+            {
+              echo "## Previous AI reviews on this PR"
+              echo ""
+              echo "Review bodies:"
+              echo '```json'
+              echo "$PRIOR"
+              echo '```'
+              echo ""
+              echo "Inline comments from previous reviews:"
+              echo '```json'
+              echo "$PRIOR_COMMENTS"
+              echo '```'
+            } > /tmp/prior_reviews.txt
+          else
+            echo "has_prior=false" >> "$GITHUB_OUTPUT"
+            echo "" > /tmp/prior_reviews.txt
+          fi
+
+      - name: Build review prompt
+        env:
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author_login }}
+        run: |
+          TRUNCATED="${{ steps.diff.outputs.truncated }}"
+          HAS_PRIOR="${{ steps.prior.outputs.has_prior }}"
+
+          # Prepend the review instructions so Codex has them in context
+          cat .github/agents/review.md > /tmp/review_prompt.txt
+
+          # Include prior AI reviews if they exist
+          if [ "$HAS_PRIOR" = "true" ]; then
+            cat >> /tmp/review_prompt.txt <<'PRIOR_HEADER'
+
+          ---
+
+          The following are your previous reviews on this PR. Build on this context:
+          do not repeat points already made unless they are still unaddressed in the
+          current diff. Focus on what changed since your last review. If previous
+          issues have been fixed, acknowledge that briefly.
+          PRIOR_HEADER
+            cat /tmp/prior_reviews.txt >> /tmp/review_prompt.txt
+          fi
+
+          cat >> /tmp/review_prompt.txt <<'PROMPT_HEADER'
+
+          ---
+
+          Review the following pull request. Follow the review instructions above.
+          Output ONLY valid JSON matching the schema specified above. No other text.
+          PROMPT_HEADER
+
+          # PR metadata
+          cat >> /tmp/review_prompt.txt <<'PROMPT_META'
+
+          PR metadata:
+          PROMPT_META
+          printf 'PR Title: %s\n' "$PR_TITLE" >> /tmp/review_prompt.txt
+          printf 'PR Author: %s\n' "$PR_AUTHOR" >> /tmp/review_prompt.txt
+
+          cat >> /tmp/review_prompt.txt <<'EOF'
+
+          If the change looks good — readable, secure, correct, and a minimal change that achieves its goal — output APPROVE, including for substantive code changes. Output COMMENT when you found real issues or genuinely cannot assess the change.
+          EOF
+
+          if [ "$TRUNCATED" = "true" ]; then
+            cat >> /tmp/review_prompt.txt <<'EOF'
+
+          WARNING: The diff was truncated due to size. You are reviewing a partial diff. Do NOT approve — use COMMENT and note that the full diff was too large for automated review.
+          EOF
+          fi
+
+          # Append the diff
+          printf '\nDiff:\n' >> /tmp/review_prompt.txt
+          cat /tmp/pr_diff.patch >> /tmp/review_prompt.txt
+
+      - name: Run Codex review
+        id: codex-review
+        env:
+          PPQ_KEY: ${{ secrets.PPQ_KEY }}
+          PPQ_MODEL: ${{ vars.PPQ_MODEL || 'openai/gpt-5.5' }}
+        run: |
+          set -euo pipefail
+
+          export CODEX_HOME="${RUNNER_TEMP}/codex-review-home"
+          mkdir -p "$CODEX_HOME"
+          path_toml=$(jq -Rn --arg value "$PATH" '$value')
+          {
+            printf 'model = "%s"\n' "$PPQ_MODEL"
+            printf '%s\n' \
+              'model_provider = "ppq"' \
+              'model_reasoning_effort = "xhigh"' \
+              'sandbox_mode = "read-only"' \
+              'approval_policy = "never"' \
+              'hide_agent_reasoning = true' \
+              '' \
+              '[model_providers.ppq]' \
+              'name = "PPQ"' \
+              'base_url = "https://api.ppq.ai/v1"' \
+              'env_key = "PPQ_KEY"' \
+              'wire_api = "responses"' \
+              '' \
+              '[history]' \
+              'persistence = "none"' \
+              '' \
+              '[shell_environment_policy]' \
+              'inherit = "all"' \
+              'ignore_default_excludes = false'
+            printf 'set = { PATH = %s }\n' "$path_toml"
+            printf '%s\n' \
+              'include_only = [' \
+              '  "PATH",' \
+              '  "HOME",' \
+              '  "CODEX_HOME",' \
+              '  "CI",' \
+              '  "GITHUB_ACTION",' \
+              '  "GITHUB_ACTIONS",' \
+              '  "GITHUB_ACTOR",' \
+              '  "GITHUB_API_URL",' \
+              '  "GITHUB_BASE_REF",' \
+              '  "GITHUB_EVENT_NAME",' \
+              '  "GITHUB_GRAPHQL_URL",' \
+              '  "GITHUB_HEAD_REF",' \
+              '  "GITHUB_JOB",' \
+              '  "GITHUB_REF",' \
+              '  "GITHUB_REF_NAME",' \
+              '  "GITHUB_REPOSITORY",' \
+              '  "GITHUB_REPOSITORY_OWNER",' \
+              '  "GITHUB_RUN_ATTEMPT",' \
+              '  "GITHUB_RUN_ID",' \
+              '  "GITHUB_RUN_NUMBER",' \
+              '  "GITHUB_SERVER_URL",' \
+              '  "GITHUB_SHA",' \
+              '  "GITHUB_WORKFLOW",' \
+              '  "GITHUB_WORKSPACE",' \
+              '  "RUNNER_ARCH",' \
+              '  "RUNNER_NAME",' \
+              '  "RUNNER_OS",' \
+              '  "RUNNER_TEMP",' \
+              '  "RUNNER_TOOL_CACHE",' \
+              '  "RUNNER_WORKSPACE",' \
+              '  "SHELL",' \
+              '  "TERM",' \
+              '  "TMPDIR",' \
+              '  "TEMP",' \
+              '  "TMP",' \
+              '  "LANG",' \
+              '  "LC_*",' \
+              '  "NODE_*",' \
+              '  "NIX_*",' \
+              '  "IN_NIX_SHELL",' \
+              ']'
+          } > "$CODEX_HOME/config.toml"
+
+          run_codex() {
+            local prompt_file="$1"
+            local output_file="$2"
+            local log_file="$3"
+
+            codex exec \
+              --ephemeral \
+              --output-last-message "$output_file" \
+              - < "$prompt_file" > "$log_file" 2>&1
+          }
+
+          print_codex_log_tail() {
+            local log_file="$1"
+
+            if [ ! -s "$log_file" ]; then
+              echo "Codex log is empty or missing: $log_file"
+              return
+            fi
+
+            echo "::group::$(basename "$log_file") tail"
+            sed -E \
+              -e "s/(Authorization: Bearer )[A-Za-z0-9._-]+/\\1<redacted>/g" \
+              -e "s/(api[_-]?key[=:] ?)[A-Za-z0-9._-]+/\\1<redacted>/Ig" \
+              "$log_file" | tail -n 120
+            echo "::endgroup::"
+          }
+
+          extract_json() {
+            local raw_file="$1"
+
+            # Prefer the full output, then fenced JSON, then a best-effort
+            # balanced-object extraction for noisy command output.
+            JSON=$(cat "$raw_file")
+            if [ -z "$JSON" ] || ! echo "$JSON" | jq . > /dev/null 2>&1; then
+              JSON=$(sed -n '/^```json/,/^```$/p' "$raw_file" | sed '1d;$d')
+            fi
+            if [ -z "$JSON" ] || ! echo "$JSON" | jq . > /dev/null 2>&1; then
+              JSON=$(python3 - "$raw_file" <<'PY'
+          import sys
+
+          text = open(sys.argv[1], encoding="utf-8").read()
+          start = text.find("{")
+          if start == -1:
+              sys.exit(0)
+
+          depth = 0
+          in_string = False
+          escaped = False
+
+          for index, char in enumerate(text[start:], start):
+              if escaped:
+                  escaped = False
+              elif char == "\\":
+                  escaped = True
+              elif char == '"':
+                  in_string = not in_string
+              elif not in_string and char == "{":
+                  depth += 1
+              elif not in_string and char == "}":
+                  depth -= 1
+                  if depth == 0:
+                      print(text[start:index + 1])
+                      break
+          PY
+          )
+            fi
+
+            if echo "$JSON" | jq . > /dev/null 2>&1; then
+              echo "$JSON"
+            else
+              return 1
+            fi
+          }
+
+          if ! run_codex /tmp/review_prompt.txt /tmp/codex_primary_raw.txt /tmp/codex_primary.log; then
+            echo "Codex primary review failed"
+            print_codex_log_tail /tmp/codex_primary.log
+            exit 1
+          fi
+
+          RAW=$(cat /tmp/codex_primary_raw.txt 2>/dev/null || true)
+          if [ -z "$RAW" ]; then
+            echo "Codex produced no output"
+            print_codex_log_tail /tmp/codex_primary.log
+            exit 1
+          fi
+
+          if ! extract_json /tmp/codex_primary_raw.txt > /tmp/review_candidates.json; then
+            echo "Failed to parse Codex output as JSON, posting raw output as comment"
+            echo "$RAW" > /tmp/review_body.txt
+            echo "verdict=COMMENT" >> "$GITHUB_OUTPUT"
+            echo "has_inline=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          printf '%s\n' \
+            'You are a validation subagent for the fedimint-sdk automated review bot.' \
+            '' \
+            'The primary reviewer produced candidate JSON findings for a pull request.' \
+            'Validate each candidate against the diff and repository context. Return the' \
+            'same JSON schema, but include only findings that are demonstrably real' \
+            'problems. Drop anything speculative, stylistic-only without project support,' \
+            'already addressed by the shown diff, or not attachable to the changed lines.' \
+            '' \
+            'Preserve every validated issue, preferably as an inline comment. Do not' \
+            'collapse multiple real issues into a summary. If the verdict is COMMENT,' \
+            'include a brief reason unless the validated inline comments make it obvious.' \
+            'Output ONLY valid JSON. No markdown fences, no preamble.' \
+            '' \
+            'Candidate review JSON:' \
+            > /tmp/validation_prompt.txt
+          cat /tmp/review_candidates.json >> /tmp/validation_prompt.txt
+          printf '\nReview instructions:\n' >> /tmp/validation_prompt.txt
+          cat .github/agents/review.md >> /tmp/validation_prompt.txt
+          printf '\nPR diff:\n' >> /tmp/validation_prompt.txt
+          cat /tmp/pr_diff.patch >> /tmp/validation_prompt.txt
+
+          if ! run_codex /tmp/validation_prompt.txt /tmp/codex_validation_raw.txt /tmp/codex_validation.log; then
+            echo "Codex validation pass failed"
+            print_codex_log_tail /tmp/codex_validation.log
+            exit 1
+          fi
+
+          VALIDATION_RAW=$(cat /tmp/codex_validation_raw.txt 2>/dev/null || true)
+          if [ -z "$VALIDATION_RAW" ]; then
+            echo "Codex validation pass produced no output"
+            print_codex_log_tail /tmp/codex_validation.log
+            exit 1
+          fi
+
+          if ! extract_json /tmp/codex_validation_raw.txt > /tmp/review.json; then
+            echo "Validation subagent failed to return parseable JSON"
+            {
+              echo "Automated review found candidate issues, but the validation pass failed. Not posting unvalidated findings."
+              echo ""
+              echo "<details><summary>Primary reviewer output</summary>"
+              echo ""
+              echo '```json'
+              cat /tmp/review_candidates.json
+              echo '```'
+              echo "</details>"
+            } > /tmp/review_body.txt
+            echo "verdict=COMMENT" >> "$GITHUB_OUTPUT"
+            echo "has_inline=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract verdict
+          VERDICT=$(jq -r '.verdict // "COMMENT"' < /tmp/review.json)
+
+          # Never let AI block a PR
+          if [ "$VERDICT" = "REQUEST_CHANGES" ]; then
+            VERDICT="COMMENT"
+          fi
+
+          # Never approve truncated diffs
+          TRUNCATED="${{ steps.diff.outputs.truncated }}"
+          if [ "$TRUNCATED" = "true" ] && [ "$VERDICT" = "APPROVE" ]; then
+            VERDICT="COMMENT"
+          fi
+
+          # Check if there are inline comments
+          INLINE_COUNT=$(jq '.inline_comments | length' < /tmp/review.json)
+
+          # Build a minimal review body — only show information a human needs
+          COMPAT_IMPACT=$(jq -r '.compat_impact // ""' < /tmp/review.json)
+          REASON=$(jq -r '.reason // ""' < /tmp/review.json)
+
+          # Treat JSON null as empty
+          [ "$COMPAT_IMPACT" = "null" ] && COMPAT_IMPACT=""
+          [ "$REASON" = "null" ] && REASON=""
+
+          BODY_PARTS=()
+
+          if [ -n "$COMPAT_IMPACT" ]; then
+            BODY_PARTS+=("**Compatibility impact:** $COMPAT_IMPACT")
+          fi
+
+          if [ -n "$REASON" ]; then
+            BODY_PARTS+=("$REASON")
+          fi
+
+          if [ "$TRUNCATED" = "true" ]; then
+            BODY_PARTS+=("*The diff was too large for complete automated review. A human reviewer should verify the full changeset.*")
+          fi
+
+          # Join parts with blank lines, or use a minimal default
+          if [ ${#BODY_PARTS[@]} -gt 0 ]; then
+            printf '%s\n\n' "${BODY_PARTS[@]}" | sed '$ d' > /tmp/review_body.txt
+          else
+            if [ "$VERDICT" = "APPROVE" ]; then
+              echo "LGTM" > /tmp/review_body.txt
+            else
+              : > /tmp/review_body.txt
+            fi
+          fi
+
+          if [ "$VERDICT" = "COMMENT" ] && [ "$INLINE_COUNT" -eq 0 ] && [ ! -s /tmp/review_body.txt ]; then
+            echo "Codex produced no validated inline comments or review body, skipping review"
+            echo "verdict=SKIP" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$INLINE_COUNT" -gt 0 ]; then
+            echo "has_inline=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_inline=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+
+      - name: Submit review with inline comments
+        if: steps.codex-review.outputs.verdict != 'SKIP'
+        env:
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+        run: |
+          VERDICT="${{ steps.codex-review.outputs.verdict }}"
+          HAS_INLINE="${{ steps.codex-review.outputs.has_inline }}"
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          COMMIT_SHA="${{ steps.pr.outputs.head_sha }}"
+
+          if [ "$VERDICT" = "APPROVE" ]; then
+            GH_EVENT="APPROVE"
+          else
+            GH_EVENT="COMMENT"
+          fi
+
+          if [ "$HAS_INLINE" = "true" ] && [ -f /tmp/review.json ]; then
+            # Build the review with inline comments via the GitHub API
+            # gh pr review doesn't support inline comments, so use the API directly
+            REVIEW_BODY=$(cat /tmp/review_body.txt)
+
+            # Build the comments array for the API
+            COMMENTS=$(jq -c '[.inline_comments[] | {
+              path: .path,
+              line: .line,
+              side: (.side // "RIGHT"),
+              body: (
+                (if .severity == "critical" then "**Critical**: "
+                 elif .severity == "warning" then "**Warning**: "
+                 else "**Nit**: "
+                 end) + .body
+              )
+            }]' < /tmp/review.json)
+
+            # Submit via GitHub REST API
+            jq -n \
+              --arg body "$REVIEW_BODY" \
+              --arg event "$GH_EVENT" \
+              --arg commit_id "$COMMIT_SHA" \
+              --argjson comments "$COMMENTS" \
+              '{
+                body: $body,
+                event: $event,
+                commit_id: $commit_id,
+                comments: $comments
+              }' | gh api \
+              "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+              --method POST \
+              --input -
+          else
+            # No inline comments, use simple gh pr review
+            if [ "$VERDICT" = "APPROVE" ]; then
+              gh pr review "$PR_NUMBER" --approve --body-file /tmp/review_body.txt
+            else
+              gh pr review "$PR_NUMBER" --comment --body-file /tmp/review_body.txt
+            fi
+          fi


### PR DESCRIPTION
Ports the fedimint-bot automation from [fedimint/fedimint](https://github.com/fedimint/fedimint) to this repository.

## What's included

- **`codex-review.yml`** — automated PR review on open / ready-for-review, when `fedimint-bot` is requested as reviewer, or via a `/review` comment. Uses `pull_request_target` with a trusted base-branch checkout (the PR is only ever handled as a text diff). Candidate findings are validated by a second Codex pass before posting; the bot can approve low-risk changes but never blocks.
- **`codex-agent.yml`** + **`codex-agent-review-comment-receiver.yml`** — `@fedimint-bot` mention handling in issues, issue comments, PR review bodies, and inline review threads, gated on active membership in the `fedimint/reviewers` team. Runs on the self-hosted runners inside the Nix dev shell.
- **`codex-ci-debug.yml`** — investigates failed `Changesets` / `Deploy Docs site to Pages` runs on `main` (plus manual `workflow_dispatch`) and comments on the culprit PR, files/updates an issue, or opens a draft fix PR.

## Adaptations vs. fedimint/fedimint

- `.github/agents/review.md` rewritten for this codebase: TypeScript/pnpm conventions, changeset + published-package back-compat, WASM/worker/IndexedDB lifecycle, bundler compatibility — replacing the consensus-critical path detection (the `consensus_impact` review field became `compat_impact`).
- Agent prompts reference `pnpm lint:fix` / `pnpm typecheck` / vitest instead of `just` recipes, and this repo's CI workflow names and `main` branch.
- Backport-specific and hourly workflows were not ported.

## Setup required before merging

- [ ] `BACKPORT_TOKEN` secret (fedimint-bot PAT) available to this repo — org-level visibility or repo secret; if it's a fine-grained PAT, it must include this repo
- [ ] `PPQ_KEY` secret available to this repo
- [ ] optional `PPQ_MODEL` variable (defaults to `openai/gpt-5.5`)
- [ ] fedimint-bot added as a collaborator so it can be requested as reviewer / assigned issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)